### PR TITLE
Madsdk/add GitHub build and deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - madsdk/add-github-build-and-deploy-action
+      - release-dr
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USERNAME }}
-          password: ${{ secrets.DEPLOY_KEY }}
+          key: ${{ secrets.DEPLOY_KEY }}
           port: ${{ secrets.DEPLOY_PORT }}
-          source: "./public/build/*"
-          target: "/home/deploy/test2"
+          source: "./public"
+          target: "/home/www/aarhus-ml-machine"


### PR DESCRIPTION
Added a simple SCP deployment workflow. Secrets are added to the site so that automatic deployment to the Hetzner VM is enabled.