### PR TITLE
Fixed jagged edges due to inconsistent svelte state

### DIFF
--- a/src/components/graphs/LiveGraph.svelte
+++ b/src/components/graphs/LiveGraph.svelte
@@ -51,12 +51,12 @@
 	// The jagged edges problem is caused by repeating the recordingStarted function.
 	// We will simply block the recording from starting, while it's recording
 	let blockRecordingStart = false;
-	$: recordingStarted(($state.isRecording || $state.isTesting) && !blockRecordingStart);
+	$: recordingStarted($state.isRecording || $state.isTesting);
 
 
 	// Function to clearly diplay the area in which users are recording
 	function recordingStarted(isRecording: boolean): void {
-		if (!isRecording) {
+		if (!isRecording || blockRecordingStart) {
 			return;
 		}
 


### PR DESCRIPTION
The issue was caused due to updates in svelte states calling the method recordingStarted() multiple times, thus causing an overlap of two recording lines.
We now just block the instantiation of a new recording line until the previous has finished.

The issue here is that updates to $state caused the recalling of recordingStarted() even though the related variables isRecording as isTesting did not change at all. Hence, any changes in $state, such as isConnected or other state variables caused this function to be called again.

I think the solution is good enough for now, but perhaps the call of this function shouldn't be determined by. The $state updating, but a more direct approach by the 'record' button or input from the micro:bit. These are however a greater refactor, that i do not think adds enough value, as it's a very niche case.