### PR TITLE
Possible to download universal hex if webusb fails

### DIFF
--- a/src/components/connection-prompt/ConnectDialogContainer.svelte
+++ b/src/components/connection-prompt/ConnectDialogContainer.svelte
@@ -89,7 +89,11 @@
         }}
         deviceState={$connectionDialogState.deviceState} />
     {:else if $connectionDialogState.connectionState === ConnectDialogStates.USB_START}
-      <FindUsbDialog onFoundUsb={onFoundUsbDevice} />
+      <FindUsbDialog
+        onUsbLinkError={() => {
+          $connectionDialogState.connectionState = ConnectDialogStates.MANUAL_TUTORIAL;
+        }}
+        onFoundUsb={onFoundUsbDevice} />
     {:else if $connectionDialogState.connectionState === ConnectDialogStates.BAD_FIRMWARE}
       <BrokenFirmwareDetected />
     {:else if $connectionDialogState.connectionState === ConnectDialogStates.USB_DOWNLOADING}

--- a/src/components/connection-prompt/usb/FindUsbDialog.svelte
+++ b/src/components/connection-prompt/usb/FindUsbDialog.svelte
@@ -4,12 +4,14 @@
   import Microbits from '../../../script/microbit-interfacing/Microbits';
 
   export let onFoundUsb: () => void;
+  export let onUsbLinkError: () => void;
 
   function onFindUsbClick() {
     Microbits.linkMicrobit()
       .then(() => onFoundUsb())
-      .catch(e => {
+      .catch((e: Error) => {
         console.log(e);
+        onUsbLinkError();
       });
   }
 
@@ -36,11 +38,11 @@
       {/if}
     </div>
     <StandardButton
-      onClick="{step === 2
+      onClick={step === 2
         ? onFindUsbClick
         : () => {
             step = 2;
-          }}">
+          }}>
       {$t(step === 1 ? 'connectMB.usb.button1' : 'connectMB.usb.button2')}
     </StandardButton>
   </div>

--- a/src/script/ml.ts
+++ b/src/script/ml.ts
@@ -10,11 +10,7 @@ import {
   TrainingStatus,
   trainingStatus,
 } from './stores/mlStore';
-import {
-  Filters, 
-  Axes,
-  determineFilter
-} from './datafunctions';
+import { Filters, Axes, determineFilter } from './datafunctions';
 import { get, type Unsubscriber } from 'svelte/store';
 import { t } from '../i18n';
 import * as tf from '@tensorflow/tfjs';
@@ -40,7 +36,9 @@ let predictionInterval: NodeJS.Timeout | undefined = undefined;
 function createModel(): LayersModel {
   const gestureData = get(gestures);
   const numberOfClasses: number = gestureData.length;
-  const inputShape = [get(settings).includedFilters.length * get(settings).includedAxes.length];
+  const inputShape = [
+    get(settings).includedFilters.length * get(settings).includedAxes.length,
+  ];
 
   const input = tf.input({ shape: inputShape });
   const normalizer = tf.layers.batchNormalization().apply(input);
@@ -128,10 +126,7 @@ export function trainModel() {
 
 export function isParametersLegal(): boolean {
   const s = get(settings);
-  return (
-    s.includedAxes.length > 0 &&
-    s.includedFilters.length > 0
-  );
+  return s.includedAxes.length > 0 && s.includedFilters.length > 0;
 }
 
 // Assess whether
@@ -191,7 +186,7 @@ function finishedTraining() {
 // makeInput reduces array of x, y and z inputs to a single number array with values.
 // Depending on user settings. There will be anywhere between 1-24 parameters in
 
-function makeInputs(sample: {x: number[], y: number[], z: number[]}): number[] {
+function makeInputs(sample: { x: number[]; y: number[]; z: number[] }): number[] {
   const dataRep: number[] = [];
 
   if (!modelSettings) {
@@ -202,9 +197,12 @@ function makeInputs(sample: {x: number[], y: number[], z: number[]}): number[] {
   // will be called with the same filters and axes untill the next training
   modelSettings.filters.forEach(filter => {
     const filterOutput = determineFilter(filter);
-    if (modelSettings.axes.includes(Axes.X)) dataRep.push(filterOutput.computeOutput(sample.x));
-    if (modelSettings.axes.includes(Axes.Y)) dataRep.push(filterOutput.computeOutput(sample.y));
-    if (modelSettings.axes.includes(Axes.Z)) dataRep.push(filterOutput.computeOutput(sample.z));
+    if (modelSettings.axes.includes(Axes.X))
+      dataRep.push(filterOutput.computeOutput(sample.x));
+    if (modelSettings.axes.includes(Axes.Y))
+      dataRep.push(filterOutput.computeOutput(sample.y));
+    if (modelSettings.axes.includes(Axes.Z))
+      dataRep.push(filterOutput.computeOutput(sample.z));
   });
 
   return dataRep;


### PR DESCRIPTION
Fixes the issue where users, that either have no microbit connected or have webusb disabled could not get access to the microbit firmware.

This is a bugfix, which poses another question. We cannot distinguish between cases where the user cancels the device request and where users have WebUSB disabled.

Maybe add another screen, which would allow users to try again, or continue manually?