### PR TITLE
Fixed npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "svelte-check": "^3.2.0",
         "svelte-jester": "^2.3.2",
         "svelte-preprocess": "^5.0.3",
-        "svelte-windicss-preprocess": "^4.2.8",
+        "svelte-windicss-preprocess": "^4.2.2",
         "ts-jest": "^29.1.0",
         "tslib": "^2.5.0",
         "typescript": "^5.0.4",
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@antfu/utils": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.2.tgz",
-      "integrity": "sha512-vy9fM3pIxZmX07dL+VX1aZe7ynZ+YyB0jY+jE6r3hOK6GNY2t6W8rzpFC4tgpbXUYABkFQwgJq2XYXlxbXAI0g==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.4.tgz",
+      "integrity": "sha512-qe8Nmh9rYI/HIspLSTwtbMFPj6dISG6+dJnOguTlPNXtCvS2uezdxscVBb7/3DrmNbQK49TDqpkSQ1chbRGdpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -4131,12 +4131,6 @@
         "lil-gui": "~0.17.0"
       }
     },
-    "node_modules/@types/throttle-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
-      "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
-      "dev": true
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
@@ -5301,12 +5295,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/defu": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
-      "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
-      "dev": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -10619,15 +10607,14 @@
       "integrity": "sha512-/dVf4Am8Rolo9DjQxmy8X8xXSKDzZWyGjf84CekWdQqvP+Y57lW1O8dxHUxqT1bGeER8ZMAOuyGEzx+gADEVWg=="
     },
     "node_modules/svelte-windicss-preprocess": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/svelte-windicss-preprocess/-/svelte-windicss-preprocess-4.2.8.tgz",
-      "integrity": "sha512-Z6pmFbHqJ19SgCiXiVRC/hlRBgZ/5LksMjPF3ilF/1HESP2L+secuaPjr3xOjJW67iZQpT2YdXzGe+MvdsJ6OQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/svelte-windicss-preprocess/-/svelte-windicss-preprocess-4.2.2.tgz",
+      "integrity": "sha512-eX8ILQaeCX9des6MCOQpVLH77QL1qPKKy5Y1qPi1fTCwW5ZvtKI/MFk0O3RR/A/CjfIkZ3tICmCWaigJSplW8w==",
       "dev": true,
       "dependencies": {
         "@iconify/json": "1.1.432",
         "fast-glob": "3.2.7",
-        "unconfig": "0.2.2",
-        "windicss": "3.5.4",
+        "windicss": "3.2.1",
         "windicss-runtime-dom": "3.0.0"
       }
     },
@@ -10648,9 +10635,9 @@
       }
     },
     "node_modules/svelte-windicss-preprocess/node_modules/windicss": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/windicss/-/windicss-3.5.4.tgz",
-      "integrity": "sha512-x2Iu0a69dtNiKHMkR886lx0WKbZI5GqvXyvGBCJ2VA6rcjKYjnzCA/Ljd6hNQBfqlkSum8J+qAVcCfLzQFI4rQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/windicss/-/windicss-3.2.1.tgz",
+      "integrity": "sha512-LusrIrryBFHAPQ/OOTbS4EWWuzI6eGeJglI9nQ3kDBr1cqH69NWt8Z8q59f9kTkgptXroejmWfksWwqgHs8EVw==",
       "dev": true,
       "bin": {
         "windicss": "cli/index.js"
@@ -10874,32 +10861,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/unconfig": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-0.2.2.tgz",
-      "integrity": "sha512-JN1MeYJ/POnjBj7NgOJJxPp6+NcD6Nd0hEuK0D89kjm9GvQQUq8HeE2Eb7PZgtu+64mWkDiqeJn1IZoLH7htPg==",
-      "dev": true,
-      "dependencies": {
-        "@antfu/utils": "^0.3.0",
-        "defu": "^5.0.0",
-        "jiti": "^1.12.9"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/unconfig/node_modules/@antfu/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==",
-      "dev": true,
-      "dependencies": {
-        "@types/throttle-debounce": "^2.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -11014,14 +10975,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.1.tgz",
-      "integrity": "sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
-        "postcss": "^8.4.21",
-        "rollup": "^3.20.2"
+        "postcss": "^8.4.23",
+        "rollup": "^3.21.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -11404,9 +11365,9 @@
       }
     },
     "@antfu/utils": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.2.tgz",
-      "integrity": "sha512-vy9fM3pIxZmX07dL+VX1aZe7ynZ+YyB0jY+jE6r3hOK6GNY2t6W8rzpFC4tgpbXUYABkFQwgJq2XYXlxbXAI0g==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.4.tgz",
+      "integrity": "sha512-qe8Nmh9rYI/HIspLSTwtbMFPj6dISG6+dJnOguTlPNXtCvS2uezdxscVBb7/3DrmNbQK49TDqpkSQ1chbRGdpQ==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -14384,12 +14345,6 @@
         "lil-gui": "~0.17.0"
       }
     },
-    "@types/throttle-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
-      "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
-      "dev": true
-    },
     "@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
@@ -15248,12 +15203,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "defu": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
-      "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
-      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -19102,15 +19051,14 @@
       "integrity": "sha512-/dVf4Am8Rolo9DjQxmy8X8xXSKDzZWyGjf84CekWdQqvP+Y57lW1O8dxHUxqT1bGeER8ZMAOuyGEzx+gADEVWg=="
     },
     "svelte-windicss-preprocess": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/svelte-windicss-preprocess/-/svelte-windicss-preprocess-4.2.8.tgz",
-      "integrity": "sha512-Z6pmFbHqJ19SgCiXiVRC/hlRBgZ/5LksMjPF3ilF/1HESP2L+secuaPjr3xOjJW67iZQpT2YdXzGe+MvdsJ6OQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/svelte-windicss-preprocess/-/svelte-windicss-preprocess-4.2.2.tgz",
+      "integrity": "sha512-eX8ILQaeCX9des6MCOQpVLH77QL1qPKKy5Y1qPi1fTCwW5ZvtKI/MFk0O3RR/A/CjfIkZ3tICmCWaigJSplW8w==",
       "dev": true,
       "requires": {
         "@iconify/json": "1.1.432",
         "fast-glob": "3.2.7",
-        "unconfig": "0.2.2",
-        "windicss": "3.5.4",
+        "windicss": "3.2.1",
         "windicss-runtime-dom": "3.0.0"
       },
       "dependencies": {
@@ -19128,9 +19076,9 @@
           }
         },
         "windicss": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/windicss/-/windicss-3.5.4.tgz",
-          "integrity": "sha512-x2Iu0a69dtNiKHMkR886lx0WKbZI5GqvXyvGBCJ2VA6rcjKYjnzCA/Ljd6hNQBfqlkSum8J+qAVcCfLzQFI4rQ==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/windicss/-/windicss-3.2.1.tgz",
+          "integrity": "sha512-LusrIrryBFHAPQ/OOTbS4EWWuzI6eGeJglI9nQ3kDBr1cqH69NWt8Z8q59f9kTkgptXroejmWfksWwqgHs8EVw==",
           "dev": true
         }
       }
@@ -19283,28 +19231,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
-    "unconfig": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-0.2.2.tgz",
-      "integrity": "sha512-JN1MeYJ/POnjBj7NgOJJxPp6+NcD6Nd0hEuK0D89kjm9GvQQUq8HeE2Eb7PZgtu+64mWkDiqeJn1IZoLH7htPg==",
-      "dev": true,
-      "requires": {
-        "@antfu/utils": "^0.3.0",
-        "defu": "^5.0.0",
-        "jiti": "^1.12.9"
-      },
-      "dependencies": {
-        "@antfu/utils": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.3.0.tgz",
-          "integrity": "sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==",
-          "dev": true,
-          "requires": {
-            "@types/throttle-debounce": "^2.1.0"
-          }
-        }
-      }
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -19385,15 +19311,15 @@
       }
     },
     "vite": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.1.tgz",
-      "integrity": "sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.17.5",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.21",
-        "rollup": "^3.20.2"
+        "postcss": "^8.4.23",
+        "rollup": "^3.21.0"
       }
     },
     "vite-plugin-environment": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "svelte-check": "^3.2.0",
     "svelte-jester": "^2.3.2",
     "svelte-preprocess": "^5.0.3",
-    "svelte-windicss-preprocess": "^4.2.8",
+    "svelte-windicss-preprocess": "^4.2.2",
     "ts-jest": "^29.1.0",
     "tslib": "^2.5.0",
     "typescript": "^5.0.4",


### PR DESCRIPTION
There is a breaking change in this update, but everything seems to work fine.

npm WARN audit Updating svelte-windicss-preprocess to 4.2.2, which is a SemVer major change.