### PR TITLE
Disabled a11y warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       preprocess: sveltePreprocess({ typescript: true }),
 
       onwarn(warning, defaultHandler) {
-        /*if (warning.code.includes('a11y')) return;  <- This disabled A11y warnings  */
+        if (warning.code.includes('a11y')) return; // Ignores the a11y warnings when compiling. This does not apply to the editor, see comment at bottom for vscode instructions
 
         // handle all other warnings normally
         defaultHandler!(warning);
@@ -26,3 +26,38 @@ export default defineConfig({
     },
   },
 });
+
+/**
+To disable a11y warnings in vscode:
+
+create file .vscode/settings.json and place
+
+{
+    "svelte.plugin.svelte.compilerWarnings": {
+      "a11y-aria-attributes": "ignore",
+      "a11y-incorrect-aria-attribute-type": "ignore",
+      "a11y-unknown-aria-attribute": "ignore",
+      "a11y-hidden": "ignore",
+      "a11y-misplaced-role": "ignore",
+      "a11y-unknown-role": "ignore",
+      "a11y-no-abstract-role": "ignore",
+      "a11y-no-redundant-roles": "ignore",
+      "a11y-role-has-required-aria-props": "ignore",
+      "a11y-accesskey": "ignore",
+      "a11y-autofocus": "ignore",
+      "a11y-misplaced-scope": "ignore",
+      "a11y-positive-tabindex": "ignore",
+      "a11y-invalid-attribute": "ignore",
+      "a11y-missing-attribute": "ignore",
+      "a11y-img-redundant-alt": "ignore",
+      "a11y-label-has-associated-control": "ignore",
+      "a11y-media-has-caption": "ignore",
+      "a11y-distracting-elements": "ignore",
+      "a11y-structure": "ignore",
+      "a11y-click-events-have-key-events": "ignore",
+      "a11y-missing-content": "ignore",
+    }
+  }
+
+  Add configuration values as needed.
+ */


### PR DESCRIPTION
Removes a11y warnings from compilation. See the comment in vite.config.ts on how to disable them in VSCode

I'm not sure how to store the settings file, so for now it is just as a comment inside the vite.config.ts file. We may want to either include .vscode/ folder (or just the settings file) or add it in the readme. I have added an issue to address this.