### PR TITLE
272 add feature flag to hide unfinished filters feature

### DIFF
--- a/src/__tests__/cookie.test.ts
+++ b/src/__tests__/cookie.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import CookieManager from '../script/CookieManager';
+import Cookies from 'js-cookie';
+
+describe('Cookie tests', () => {
+  test('Should get feature flag if set', () => {
+    const someFlag = 'someflag';
+    Cookies.set('fflags', 'someflag + some junk');
+    expect(CookieManager.hasFeatureFlag(someFlag)).toBeTruthy();
+  });
+
+  test('Should NOT get feature flag if NOT set', () => {
+    const someFlag = 'someflag';
+    Cookies.set('fflags', 'some junk');
+    expect(CookieManager.hasFeatureFlag(someFlag)).toBeFalsy();
+  });
+
+  test('Should NOT get feature flag if no fflags cookie is set', () => {
+    const someFlag = 'someflag';
+    expect(CookieManager.hasFeatureFlag(someFlag)).toBeFalsy();
+  });
+});

--- a/src/__tests__/cookie.test.ts
+++ b/src/__tests__/cookie.test.ts
@@ -2,6 +2,12 @@
  * @jest-environment jsdom
  */
 
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 import CookieManager from '../script/CookieManager';
 import Cookies from 'js-cookie';
 

--- a/src/components/control-bar/control-bar-items/ContactUsControlBarButton.svelte
+++ b/src/components/control-bar/control-bar-items/ContactUsControlBarButton.svelte
@@ -17,10 +17,12 @@
         class="text-red-500 hover:underline">
         {$t('content.index.contactMail')}
       </a>
-      <p class="w-60">
-       {$t('content.index.contactBodyGithub')}
-        <a class="text-link hover:underline"
-          href="https://github.com/microbit-foundation/cctd-ml-machine" >cctd-ml-mahine</a>
+    </p>
+    <p class="w-60">
+      {$t('content.index.contactBodyGithub')}
+      <a
+        class="text-link hover:underline"
+        href="https://github.com/microbit-foundation/cctd-ml-machine">cctd-ml-mahine</a>
     </p>
   </StandardDialog>
   <StandardButton

--- a/src/pages/Homepage.svelte
+++ b/src/pages/Homepage.svelte
@@ -43,7 +43,10 @@
     </div>
     <div class="flex-grow flex items-end">
       <div class="pb-2 pl-10">
-        <p>{$t('content.index.acknowledgement')} - <a class="text-link hover:underline" href="https://cctd.au.dk/">cctd.au.dk</a></p> 
+        <p>
+          {$t('content.index.acknowledgement')} -
+          <a class="text-link hover:underline" href="https://cctd.au.dk/">cctd.au.dk</a>
+        </p>
       </div>
     </div>
   </div>

--- a/src/pages/home-page-content-tiles/DoItYourselfMachineLearningTile.svelte
+++ b/src/pages/home-page-content-tiles/DoItYourselfMachineLearningTile.svelte
@@ -36,5 +36,6 @@
 <br />
 <p>
   {$t('content.index.oldVersion')}
-  <a class="text-link hover:underline" href="https://www.v0.ml-machine.org/">v0.ml-machine.org</a>
+  <a class="text-link hover:underline" href="https://www.v0.ml-machine.org/"
+    >v0.ml-machine.org</a>
 </p>

--- a/src/pages/home-page-content-tiles/DoItYourselfMachineLearningTile.svelte
+++ b/src/pages/home-page-content-tiles/DoItYourselfMachineLearningTile.svelte
@@ -36,6 +36,7 @@
 <br />
 <p>
   {$t('content.index.oldVersion')}
-  <a class="text-link hover:underline" href="https://www.v0.ml-machine.org/"
-    >v0.ml-machine.org</a>
+  <a class="text-link hover:underline" href="https://www.v0.ml-machine.org/">
+    v0.ml-machine.org
+  </a>
 </p>

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -17,6 +17,7 @@
   import ExpandableControlBarMenu from '../../components/control-bar/control-bar-items/ExpandableControlBarMenu.svelte';
   import StandardButton from '../../components/StandardButton.svelte';
   import { Paths, navigate } from '../../router/paths';
+    import CookieManager from '../../script/CookieManager';
 
   const sufficientData = hasSufficientData();
 
@@ -50,6 +51,7 @@
   </div>
 </StandardDialog>
 <div class="flex flex-col h-full">
+  {#if CookieManager.hasFeatureFlag("filters")}
   <ControlBar>
     <ExpandableControlBarMenu>
       <StandardButton
@@ -62,6 +64,7 @@
       </StandardButton>
     </ExpandableControlBarMenu>
   </ControlBar>
+  {/if}
   <div class="flex flex-col flex-grow justify-center items-center text-center">
     {#if !$state.isInputConnected}
       <PleaseConnectFirst />

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -17,7 +17,7 @@
   import ExpandableControlBarMenu from '../../components/control-bar/control-bar-items/ExpandableControlBarMenu.svelte';
   import StandardButton from '../../components/StandardButton.svelte';
   import { Paths, navigate } from '../../router/paths';
-    import CookieManager from '../../script/CookieManager';
+  import CookieManager from '../../script/CookieManager';
 
   const sufficientData = hasSufficientData();
 
@@ -51,19 +51,19 @@
   </div>
 </StandardDialog>
 <div class="flex flex-col h-full">
-  {#if CookieManager.hasFeatureFlag("filters")}
-  <ControlBar>
-    <ExpandableControlBarMenu>
-      <StandardButton
-        small
-        outlined
-        onClick={() => {
-          navigate(Paths.FILTERS);
-        }}>
-        {$t('content.trainer.controlbar.filters')}
-      </StandardButton>
-    </ExpandableControlBarMenu>
-  </ControlBar>
+  {#if CookieManager.hasFeatureFlag('filters')}
+    <ControlBar>
+      <ExpandableControlBarMenu>
+        <StandardButton
+          small
+          outlined
+          onClick={() => {
+            navigate(Paths.FILTERS);
+          }}>
+          {$t('content.trainer.controlbar.filters')}
+        </StandardButton>
+      </ExpandableControlBarMenu>
+    </ControlBar>
   {/if}
   <div class="flex flex-col flex-grow justify-center items-center text-center">
     {#if !$state.isInputConnected}

--- a/src/script/CookieManager.ts
+++ b/src/script/CookieManager.ts
@@ -11,6 +11,7 @@ export type ComplianceChoices = {
 class CookieManager {
   private static reconnectCookieName = 'reconnect_flag';
   private static complianceCookieName = 'cookie_consent';
+  private static featureFlagsCookieName = 'fflags';
   private static complianceCookieChangeEvent = new Event('complianceCookieChange');
 
   public static isReconnectFlagSet(): boolean {
@@ -44,6 +45,14 @@ class CookieManager {
       expires: 365,
     });
     document.dispatchEvent(this.complianceCookieChangeEvent);
+  }
+
+  public static hasFeatureFlag(flag: string): boolean {
+    const flags = Cookies.get('fflags');
+    if (!flags) {
+      return false;
+    }
+    return flags.toLowerCase().includes(flag.toLowerCase());
   }
 }
 


### PR DESCRIPTION
The filters page are now hidden from users who do not have the feature flag 'filters'

![image](https://github.com/microbit-foundation/cctd-ml-machine/assets/6570193/6dd74aa3-4b2a-4998-b1f7-335a1e8c6703)

**Note** that it is still accessible from routing `/training/filters` or manually setting the ´fflags´ cookie with value ´filters´