### PR TITLE
Update appInsights.ts

### DIFF
--- a/src/appInsights.ts
+++ b/src/appInsights.ts
@@ -10,7 +10,7 @@ const load = () => {
 const appInsights = new ApplicationInsights({
   config: {
     connectionString:
-      'InstrumentationKey=a475fa05-ab5e-4a01-82a0-0a1b58af45da;IngestionEndpoint=https://northeurope-2.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/',
+      'InstrumentationKey=9ff70ae9-1397-4b70-85f2-2d3e80a29113;IngestionEndpoint=https://northeurope-2.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/',
   },
 });
 


### PR DESCRIPTION
Issue: production branch and dr-release branch have the same app insights-key, so we cannot see which version users visit.

Hotfix: Change key on production branch to be different from key on dr-release