### PR TITLE
added routing configuration for Azure static web apps service

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+    "navigationFallback": {
+      "rewrite": "/index.html",
+      "exclude": ["*.{png,jpg,gif,css,js,icosvg}"]
+    }
+}


### PR DESCRIPTION
I have added a configuration file.

Maybe you will take a look at the "excluded" @r59q? (It is probably fine).

We cannot test if it works before we merge it to main and it is deployed on Azure. Unless, one of us install the Azure web apps client - put let's just merge it and see if it works.