### PR TITLE
Added onUartMessageReceived to ConnectionBehaviour interface + detect makecode

### DIFF
--- a/src/__tests__/mocks/SpyConnectionBehaviour.ts
+++ b/src/__tests__/mocks/SpyConnectionBehaviour.ts
@@ -12,6 +12,9 @@ import MBSpecs from '../../script/microbit-interfacing/MBSpecs';
  * Use this for checking the micro:bit behaviour.
  */
 class SpyConnectionBehaviour implements ConnectionBehaviour {
+  onUartMessageReceived(message: string): void {
+    throw new Error('Method not implemented.');
+  }
 
   private hasConnected = false;
   private hasDisconnected = false;

--- a/src/__tests__/mocks/SpyConnectionBehaviour.ts
+++ b/src/__tests__/mocks/SpyConnectionBehaviour.ts
@@ -12,6 +12,7 @@ import MBSpecs from '../../script/microbit-interfacing/MBSpecs';
  * Use this for checking the micro:bit behaviour.
  */
 class SpyConnectionBehaviour implements ConnectionBehaviour {
+
   private hasConnected = false;
   private hasDisconnected = false;
   private wasExpelled = false;
@@ -21,6 +22,10 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
   private connectedName: string | undefined = undefined;
   private connectedMicrobit: MicrobitBluetooth | undefined = undefined;
 
+  onGestureRecognized(id: number, gestureName: string): void {
+    throw new Error('Method not implemented.');
+  }
+
   onConnected(name: string): void {
     this.hasConnected = true;
   }
@@ -28,7 +33,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     this.hasDisconnected = true;
   }
 
-  accelerometerChange(x: number, y: number, z: number): void {}
+  accelerometerChange(x: number, y: number, z: number): void { }
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string): void {
     this.hasConnected = true;
@@ -50,7 +55,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     }
   }
 
-  buttonChange(buttonState: MBSpecs.ButtonState, button: MBSpecs.Button): void {}
+  buttonChange(buttonState: MBSpecs.ButtonState, button: MBSpecs.Button): void { }
 
   isAssigned(): boolean {
     return false;
@@ -80,7 +85,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     return this.connectedName;
   }
 
-  onReady(): void {}
+  onReady(): void { }
 
   onBluetoothConnectionError(error?: unknown): void {
     this.hasFailedConnection = true;

--- a/src/components/OutputGesture.svelte
+++ b/src/components/OutputGesture.svelte
@@ -35,6 +35,7 @@
   import Information from './information/Information.svelte';
   import { PinTurnOnState } from './output/PinSelectorUtil';
   import MBSpecs from '../script/microbit-interfacing/MBSpecs';
+  import ConnectionBehaviours from '../script/connection-behaviours/ConnectionBehaviours';
 
   type TriggerAction = 'turnOn' | 'turnOff' | 'none';
 
@@ -84,6 +85,10 @@
       triggerComponents();
       playSound();
       wasTriggered = true;
+      ConnectionBehaviours.getOutputBehaviour().onGestureRecognized(
+        gesture.ID,
+        gesture.name,
+      );
     } else {
       wasTriggered = false;
     }

--- a/src/script/connection-behaviours/ConnectionBehaviour.ts
+++ b/src/script/connection-behaviours/ConnectionBehaviour.ts
@@ -43,6 +43,12 @@ interface ConnectionBehaviour {
   onReady(): void;
 
   /**
+   * What should happen when a gesture is recognized?
+   * @param gestureName The name of the gesture, which was recognized
+   */
+  onGestureRecognized(id: number, gestureName: string): void;
+
+  /**
    * What should happen when the micro:bit loses connection via Bluetooth
    */
   onDisconnected(): void;

--- a/src/script/connection-behaviours/ConnectionBehaviour.ts
+++ b/src/script/connection-behaviours/ConnectionBehaviour.ts
@@ -49,6 +49,11 @@ interface ConnectionBehaviour {
   onGestureRecognized(id: number, gestureName: string): void;
 
   /**
+   * What should happen when a message is received
+   */
+  onUartMessageReceived(message: string): void;
+
+  /**
    * What should happen when the micro:bit loses connection via Bluetooth
    */
   onDisconnected(): void;

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -38,6 +38,10 @@ class InputBehaviour extends LoggingDecorator {
     });
   }
 
+  onGestureRecognized(id: number, gestureName: string): void {
+    super.onGestureRecognized(id, gestureName);
+  }
+
   onReady() {
     super.onReady();
     clearTimeout(this.reconnectTimeout);

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -42,6 +42,10 @@ class InputBehaviour extends LoggingDecorator {
     super.onGestureRecognized(id, gestureName);
   }
 
+  onUartMessageReceived(message: string): void {
+    super.onUartMessageReceived(message);
+  }
+
   onReady() {
     super.onReady();
     clearTimeout(this.reconnectTimeout);
@@ -53,6 +57,7 @@ class InputBehaviour extends LoggingDecorator {
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string) {
     super.onAssigned(microbitBluetooth, name);
+    microbitBluetooth.listenToUART(this.onUartMessageReceived)
     state.update(s => {
       s.isInputAssigned = true;
       return s;

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -44,6 +44,16 @@ class InputBehaviour extends LoggingDecorator {
 
   onUartMessageReceived(message: string): void {
     super.onUartMessageReceived(message);
+    if (message === "id_mkcd") {
+      this.announceIsMakecode();
+    }
+  }
+
+  private announceIsMakecode() {
+    state.update(s => {
+      s.isInputMakecodeHex = true;
+      return s;
+    })
   }
 
   onReady() {
@@ -57,7 +67,7 @@ class InputBehaviour extends LoggingDecorator {
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string) {
     super.onAssigned(microbitBluetooth, name);
-    microbitBluetooth.listenToUART(this.onUartMessageReceived)
+    microbitBluetooth.listenToUART((data) => this.onUartMessageReceived(data))
     state.update(s => {
       s.isInputAssigned = true;
       return s;
@@ -93,6 +103,7 @@ class InputBehaviour extends LoggingDecorator {
       s.offerReconnect = false;
       s.isInputReady = false;
       s.reconnectState = DeviceRequestStates.NONE;
+      s.isInputMakecodeHex = false;
       return s;
     });
   }

--- a/src/script/connection-behaviours/LoggingDecorator.ts
+++ b/src/script/connection-behaviours/LoggingDecorator.ts
@@ -13,6 +13,7 @@ import Environment from '../Environment';
  * Used for logging / Decorator pattern
  */
 abstract class LoggingDecorator implements ConnectionBehaviour {
+
   private enableLogging: boolean = Environment.isInDevelopment && true;
 
   // For preventing spam of accelerometer data
@@ -21,6 +22,10 @@ abstract class LoggingDecorator implements ConnectionBehaviour {
 
   onBluetoothConnectionError(error?: unknown): void {
     this.enableLogging && console.log('An error occured while connecting.', error);
+  }
+
+  onGestureRecognized(id: number, gestureName: string): void {
+    this.enableLogging && console.log(`Gesture '${gestureName}' with id ${id} was recognized`)
   }
 
   onReady(): void {

--- a/src/script/connection-behaviours/LoggingDecorator.ts
+++ b/src/script/connection-behaviours/LoggingDecorator.ts
@@ -25,7 +25,11 @@ abstract class LoggingDecorator implements ConnectionBehaviour {
   }
 
   onGestureRecognized(id: number, gestureName: string): void {
-    this.enableLogging && console.log(`Gesture '${gestureName}' with id ${id} was recognized`)
+    this.enableLogging && console.log(`Gesture '${gestureName}' with id ${id} was recognized`);
+  }
+
+  onUartMessageReceived(message: string): void {
+    this.enableLogging && console.log(`Message '${message}' was received`);
   }
 
   onReady(): void {

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -33,6 +33,9 @@ class OutputBehaviour extends LoggingDecorator {
 
   onGestureRecognized(id: number, gestureName: string): void {
     super.onGestureRecognized(id, gestureName);
+    if (Microbits.isOutputReady()) {
+      Microbits.sendUARTGestureMessageToOutput(gestureName);
+    }
   }
 
   onUartMessageReceived(message: string): void {

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -31,12 +31,16 @@ class OutputBehaviour extends LoggingDecorator {
     });
   }
 
+  onGestureRecognized(id: number, gestureName: string): void {
+    super.onGestureRecognized(id, gestureName);
+  }
+
   onReady() {
     super.onReady();
     // Reset any output pins currently active.
-    const pinResetArguments: { pin: number; on: boolean }[] = [];
+    const pinResetArguments: { pin: MBSpecs.UsableIOPin; on: boolean }[] = [];
     StaticConfiguration.supportedPins.forEach(pin => {
-      const argument = { pin: parseInt(pin), on: false };
+      const argument = { pin: pin, on: false };
       pinResetArguments.push(argument);
     });
     Microbits.sendToOutputPin(pinResetArguments);

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -37,10 +37,28 @@ class OutputBehaviour extends LoggingDecorator {
 
   onUartMessageReceived(message: string): void {
     super.onUartMessageReceived(message);
+    if (message === "id_mkcd") {
+      this.announceIsMakecode();
+    }
+  }
+
+  private announceIsMakecode() {
+    state.update(s => {
+      s.isOutputMakecodeHex = true;
+      return s;
+    })
   }
 
   onReady() {
     super.onReady();
+
+    if (Microbits.isInputOutputTheSame()) {
+      state.update(s => {
+        s.isOutputMakecodeHex = s.isInputMakecodeHex;
+        return s;
+      })
+    }
+
     // Reset any output pins currently active.
     const pinResetArguments: { pin: MBSpecs.UsableIOPin; on: boolean }[] = [];
     StaticConfiguration.supportedPins.forEach(pin => {
@@ -58,7 +76,7 @@ class OutputBehaviour extends LoggingDecorator {
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string) {
     super.onAssigned(microbitBluetooth, name);
-    microbitBluetooth.listenToUART(this.onUartMessageReceived)
+    microbitBluetooth.listenToUART((data) => this.onUartMessageReceived(data))
     state.update(s => {
       s.isOutputAssigned = true;
       return s;
@@ -121,6 +139,7 @@ class OutputBehaviour extends LoggingDecorator {
     state.update(s => {
       s.isOutputConnected = false;
       s.isOutputReady = false;
+      s.isOutputMakecodeHex = false;
       return s;
     });
   }

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -35,6 +35,10 @@ class OutputBehaviour extends LoggingDecorator {
     super.onGestureRecognized(id, gestureName);
   }
 
+  onUartMessageReceived(message: string): void {
+    super.onUartMessageReceived(message);
+  }
+
   onReady() {
     super.onReady();
     // Reset any output pins currently active.
@@ -54,6 +58,7 @@ class OutputBehaviour extends LoggingDecorator {
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string) {
     super.onAssigned(microbitBluetooth, name);
+    microbitBluetooth.listenToUART(this.onUartMessageReceived)
     state.update(s => {
       s.isOutputAssigned = true;
       return s;

--- a/src/script/microbit-interfacing/MicrobitBluetooth.ts
+++ b/src/script/microbit-interfacing/MicrobitBluetooth.ts
@@ -20,6 +20,7 @@ export class MicrobitBluetooth {
   private readonly device: BluetoothDevice;
 
   private dcListener: OmitThisParameter<(event: Event) => void>;
+  private uartListeners: ((data: string) => void)[];
 
   /**
    * Constructs a bluetooth connection object. Should not be called directly.
@@ -45,6 +46,7 @@ export class MicrobitBluetooth {
     private onReconnectFailed: () => void,
   ) {
     this.dcListener = this.disconnectListener.bind(this);
+    this.uartListeners = [];
     this.device = gattServer.device;
     this.device.addEventListener('gattserverdisconnected', this.dcListener);
   }
@@ -153,31 +155,43 @@ export class MicrobitBluetooth {
     }
   }
 
+  private uartIncomingMessageHandler(data: string): void {
+    this.uartListeners.forEach((listener) => {
+      listener(data);
+    })
+  }
+
   /**
-   * Listen to the UART data transmission characteristic
+   * Listen to the UART data transmission characteristic.
+   * 
+   * Note: The limit for UART messages are 20 bytes. If messages larger than 20 bytes are
+   * received, they will trigger the given 'onDataReceived' multiple times  
+   * 
    * @param {(string) => void} onDataReceived Callback to be called when data is received.
    */
   public async listenToUART(onDataReceived: (data: string) => void): Promise<void> {
-    const uartService: BluetoothRemoteGATTService = await this.getUARTService();
-    const uartTXCharacteristic: BluetoothRemoteGATTCharacteristic =
-      await uartService.getCharacteristic(MBSpecs.Characteristics.UART_DATA_TX);
+    this.uartListeners.push(onDataReceived);
+    if (this.uartListeners.length == 1) {
+      const uartService: BluetoothRemoteGATTService = await this.getUARTService();
+      const uartTXCharacteristic: BluetoothRemoteGATTCharacteristic =
+        await uartService.getCharacteristic(MBSpecs.Characteristics.UART_DATA_TX);
 
-    await uartTXCharacteristic.startNotifications();
+      await uartTXCharacteristic.startNotifications();
 
-    uartTXCharacteristic.addEventListener(
-      'characteristicvaluechanged',
-      (event: Event) => {
-        // Convert the data to a string.
-        const receivedData: number[] = [];
-        const target: CharacteristicDataTarget = event.target as CharacteristicDataTarget;
-        for (let i = 0; i < target.value.byteLength; i += 1) {
-          receivedData[i] = target.value.getUint8(i);
-        }
-        const receivedString = String.fromCharCode.apply(null, receivedData);
-
-        onDataReceived(receivedString);
-      },
-    );
+      uartTXCharacteristic.addEventListener(
+        'characteristicvaluechanged',
+        (event: Event) => {
+          // Convert the data to a string.
+          const receivedData: number[] = [];
+          const target: CharacteristicDataTarget = event.target as CharacteristicDataTarget;
+          for (let i = 0; i < target.value.byteLength; i += 1) {
+            receivedData[i] = target.value.getUint8(i);
+          }
+          const receivedString = String.fromCharCode.apply(null, receivedData);
+          this.uartIncomingMessageHandler(receivedString);
+        },
+      );
+    }
   }
 
   /**

--- a/src/script/microbit-interfacing/MicrobitBluetooth.ts
+++ b/src/script/microbit-interfacing/MicrobitBluetooth.ts
@@ -332,7 +332,7 @@ export class MicrobitBluetooth {
             optionalServices: [
               MBSpecs.Services.UART_SERVICE,
               MBSpecs.Services.ACCEL_SERVICE,
-              MBSpecs.Services.DEVICE_INFO_SERVICE,
+              // MBSpecs.Services.DEVICE_INFO_SERVICE,
               MBSpecs.Services.LED_SERVICE,
               MBSpecs.Services.IO_SERVICE,
               MBSpecs.Services.BUTTON_SERVICE,

--- a/src/script/microbit-interfacing/MicrobitBluetooth.ts
+++ b/src/script/microbit-interfacing/MicrobitBluetooth.ts
@@ -346,7 +346,7 @@ export class MicrobitBluetooth {
             optionalServices: [
               MBSpecs.Services.UART_SERVICE,
               MBSpecs.Services.ACCEL_SERVICE,
-              // MBSpecs.Services.DEVICE_INFO_SERVICE,
+              MBSpecs.Services.DEVICE_INFO_SERVICE,
               MBSpecs.Services.LED_SERVICE,
               MBSpecs.Services.IO_SERVICE,
               MBSpecs.Services.BUTTON_SERVICE,

--- a/src/script/microbit-interfacing/Microbits.ts
+++ b/src/script/microbit-interfacing/Microbits.ts
@@ -613,6 +613,7 @@ class Microbits {
     this.assignedOutputMicrobit = this.getInput();
     this.outputName = this.inputName;
     this.outputVersion = this.inputVersion;
+
     ConnectionBehaviours.getOutputBehaviour().onAssigned(
       this.getOutput(),
       this.outputName,

--- a/src/script/microbit-interfacing/Microbits.ts
+++ b/src/script/microbit-interfacing/Microbits.ts
@@ -690,6 +690,9 @@ class Microbits {
    * @param value The gesture name
    */
   public static sendUARTGestureMessageToOutput(value: string) {
+    if (!this.isOutputReady()) {
+      throw new Error("No output microbit is ready to receive UART gesture messages")
+    }
     this.sendToOutputUart('g', value);
   }
 


### PR DESCRIPTION
- Adds onUartMessageReceived 
- Can detect when hex file is from makecode (if it sends UART message 'id_mkcd')
- App state is updated when makecode hex is detected
- Adds onGestureRecognized to the ConnectionBehaviour interface and is now triggered whenever a gesture is recognized. Currently only prints a line in console if in dev env
- Sends Uart messages every time a gesture is recognized


Technically, makecode extension is now supported. Try it with the sample project https://makecode.microbit.org/_9cxc7089o9LT (however the LEDS are still controlled by the website, so there may be some jitter)