### PR TITLE
Gestures wrapper class,  GestureOutputTile and disable IO when makecode

### DIFF
--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -33,7 +33,7 @@ class StaticConfiguration {
   public static readonly gestureNameMaxLength = 25;
 
   // Default required confidence level
-  public static readonly defaultRequiredConfidence = 80;
+  public static readonly defaultRequiredConfidence = 0.8;
 
   public static initialMLSettings = {
     duration: 1800,

--- a/src/components/output/OutputGesture.svelte
+++ b/src/components/output/OutputGesture.svelte
@@ -4,15 +4,63 @@
   SPDX-License-Identifier: MIT
  -->
 <script lang="ts">
+  import CookieManager from '../../script/CookieManager';
+  import Gestures from '../../script/Gestures';
+  import ConnectionBehaviours from '../../script/connection-behaviours/ConnectionBehaviours';
+  import Microbits from '../../script/microbit-interfacing/Microbits';
   import { GestureData } from '../../script/stores/mlStore';
+  import { state } from '../../script/stores/uiStore';
   import OutputGestureStack from './OutputGestureStack.svelte';
   import OutputGestureTile from './OutputGestureTile.svelte';
+
+  export let gesture: GestureData;
+  let wasTriggered = false;
+
+  const confidence = Gestures.getConfidence(gesture.ID);
+  const requiredConfidence = Gestures.getRequiredConfidence(gesture.ID);
+
+  $: currentConfidence = $state.isInputReady ? $confidence : 0;
+
+  $: {
+    console.log($requiredConfidence);
+  }
+
+  $: {
+    let isConfident = $requiredConfidence <= currentConfidence * 100;
+    if (isConfident) {
+      if (!wasTriggered) {
+        wasTurnedOn();
+      }
+      wasTriggered = true;
+    } else {
+      if (wasTriggered) {
+        wasTurnedOff();
+      }
+      wasTriggered = false;
+    }
+  }
+  const wasTurnedOff = () => {
+    // Some action here
+    console.log('was turned off' + gesture.name);
+  };
+  const wasTurnedOn = () => {
+    console.log('was turned on' + gesture.name);
+    // TODO: Will be removed in the future - see https://github.com/microbit-foundation/cctd-ml-machine/issues/305 @amh
+    if (CookieManager.hasFeatureFlag('mkcd')) {
+      if (Microbits.isOutputMakecode()) {
+        ConnectionBehaviours.getOutputBehaviour().onGestureRecognized(
+          gesture.ID,
+          gesture.name,
+        );
+        return;
+      }
+    }
+  };
 
   export let variant: 'stack' | 'tile';
   export let onUserInteraction: () => void = () => {
     return;
   };
-  export let gesture: GestureData;
 </script>
 
 {#if variant === 'stack'}
@@ -20,5 +68,5 @@
 {/if}
 
 {#if variant === 'tile'}
-  <OutputGestureTile {gesture} />
+  <OutputGestureTile {confidence} {requiredConfidence} {gesture} />
 {/if}

--- a/src/script/Gestures.ts
+++ b/src/script/Gestures.ts
@@ -1,0 +1,24 @@
+import { Writable, get, writable } from "svelte/store";
+import StaticConfiguration from "../StaticConfiguration";
+
+class Gestures {
+
+    private static confidences: Map<number, Writable<number>> = new Map();
+    private static requiredConfidences: Map<number, Writable<number>> = new Map();
+
+    public static getConfidence(ID: number): Writable<number> {
+        if (!this.confidences.has(ID)) {
+            this.confidences.set(ID, writable(0));
+        }
+        return this.confidences.get(ID)!;
+    }
+
+    public static getRequiredConfidence(ID: number): Writable<number> {
+        if (!this.requiredConfidences.has(ID)) {
+            this.requiredConfidences.set(ID, writable(StaticConfiguration.defaultRequiredConfidence));
+        }
+        return this.requiredConfidences.get(ID)!;
+    }
+}
+
+export default Gestures;

--- a/src/script/Gestures.ts
+++ b/src/script/Gestures.ts
@@ -1,4 +1,10 @@
-import { Writable, get, writable } from "svelte/store";
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Writable, writable } from "svelte/store";
 import StaticConfiguration from "../StaticConfiguration";
 
 class Gestures {

--- a/src/script/connection-behaviours/LoggingDecorator.ts
+++ b/src/script/connection-behaviours/LoggingDecorator.ts
@@ -14,7 +14,7 @@ import Environment from '../Environment';
  */
 abstract class LoggingDecorator implements ConnectionBehaviour {
 
-  private enableLogging: boolean = Environment.isInDevelopment && true;
+  private enableLogging: boolean = Environment.isInDevelopment && false;
 
   // For preventing spam of accelerometer data
   private logTimer = new Date().getTime();

--- a/src/script/connection-behaviours/LoggingDecorator.ts
+++ b/src/script/connection-behaviours/LoggingDecorator.ts
@@ -14,7 +14,7 @@ import Environment from '../Environment';
  */
 abstract class LoggingDecorator implements ConnectionBehaviour {
 
-  private enableLogging: boolean = Environment.isInDevelopment && false;
+  private enableLogging: boolean = Environment.isInDevelopment && true;
 
   // For preventing spam of accelerometer data
   private logTimer = new Date().getTime();

--- a/src/script/ml.ts
+++ b/src/script/ml.ts
@@ -21,6 +21,7 @@ import { get, type Unsubscriber } from 'svelte/store';
 import { t } from '../i18n';
 import * as tf from '@tensorflow/tfjs';
 import { LayersModel, SymbolicTensor, Tensor } from '@tensorflow/tfjs';
+import Gestures from './Gestures';
 
 let text: (key: string, vars?: object) => string;
 t.subscribe(t => (text = t));
@@ -292,6 +293,10 @@ function tfHandlePrediction(result: Float32Array) {
   const gestureData = get(gestures);
 
   gestureData.forEach(({ ID }, index) => {
+    Gestures.getConfidence(ID).update(val => {
+      val = result[index];
+      return val;
+    })
     gestureConfidences.update(confidenceMap => {
       confidenceMap[ID] = result[index];
       return confidenceMap;


### PR DESCRIPTION
- Adds a new class, that makes it easier to handle gesture state for confidence/requiredConfidence
    - It is the first part of a series of refactors that should separate the state logic from svelte components, such that svelte components wont cause system-wide state changes, which are difficult to track down
- Adds a OutputGestureTile, which is a refactored version of the old OutputGesture, that will be shown in a grid-based layout on model page when on makecode