### PR TITLE
Stability and workflow changes for makecode

### DIFF
--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -13,7 +13,7 @@ import MBSpecs from './script/microbit-interfacing/MBSpecs';
 
 class StaticConfiguration {
   // in milliseconds, how long should be wait for reconnect before determining something catestrophic happened during the process?
-  public static readonly reconnectTimeoutDuration: number = 5000;
+  public static readonly reconnectTimeoutDuration: number = 7500;
 
   // After how long should we consider the connection lost if ping was not able to conclude?
   public static readonly connectionLostTimeoutDuration: number = 3000;

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -12,11 +12,6 @@
   import ModelPageStackView from './ModelPageStackView.svelte';
   import ModelPageTileView from './ModelPageTileView.svelte';
 
-  const switchView = () => {
-    $state.modelView =
-      $state.modelView == ModelView.STACK ? ModelView.TILE : ModelView.STACK;
-  };
-
   const openMakeCodeInNewTab = () => {
     window.open(
       'https://makecode.microbit.org/#pub:04730-01245-34848-93416',

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -28,8 +28,9 @@
 <div>
   <ControlBar>
     <ExpandableControlBarMenu>
-      <StandardButton small outlined onClick={openMakeCodeInNewTab}
-        >MakeCode</StandardButton>
+      <StandardButton small outlined onClick={openMakeCodeInNewTab}>
+        MakeCode HEX
+      </StandardButton>
     </ExpandableControlBarMenu>
   </ControlBar>
 </div>

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -9,6 +9,7 @@
   import { ModelView, state } from '../../script/stores/uiStore';
   import ModelPageStackView from './ModelPageStackView.svelte';
   import ModelPageTileView from './ModelPageTileView.svelte';
+  import windiConfig from '../../../windi.config';
 
   const switchView = () => {
     $state.modelView =
@@ -25,16 +26,4 @@
   {:else}
     <ModelPageStackView />
   {/if}
-</div>
-<div class="absolute bottom-0 right-0 p-1">
-  <div class="border-1 bg-backgroundlight p-1">
-    <button class="text-primary text-sm" on:click={switchView}>
-      {#if $state.modelView == ModelView.STACK}
-        Show makecode >>
-      {/if}
-      {#if $state.modelView == ModelView.TILE}
-        Go back >>
-      {/if}
-    </button>
-  </div>
 </div>

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -5,20 +5,33 @@
  -->
 
 <script lang="ts">
+  import StandardButton from '../../components/StandardButton.svelte';
   import ControlBar from '../../components/control-bar/ControlBar.svelte';
+  import ExpandableControlBarMenu from '../../components/control-bar/control-bar-items/ExpandableControlBarMenu.svelte';
   import { ModelView, state } from '../../script/stores/uiStore';
   import ModelPageStackView from './ModelPageStackView.svelte';
   import ModelPageTileView from './ModelPageTileView.svelte';
-  import windiConfig from '../../../windi.config';
 
   const switchView = () => {
     $state.modelView =
       $state.modelView == ModelView.STACK ? ModelView.TILE : ModelView.STACK;
   };
+
+  const openMakeCodeInNewTab = () => {
+    window.open(
+      'https://makecode.microbit.org/#pub:04730-01245-34848-93416',
+      '_blank', // <- This is what makes it open in a new window.
+    );
+  };
 </script>
 
 <div>
-  <ControlBar />
+  <ControlBar>
+    <ExpandableControlBarMenu>
+      <StandardButton small outlined onClick={openMakeCodeInNewTab}
+        >MakeCode</StandardButton>
+    </ExpandableControlBarMenu>
+  </ControlBar>
 </div>
 <div class="pt-4 pl-3">
   {#if $state.modelView == ModelView.TILE}

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -5,7 +5,7 @@
  */
 
 import type MicrobitBluetooth from '../microbit-interfacing/MicrobitBluetooth';
-import { buttonPressed, state } from '../stores/uiStore';
+import { ModelView, buttonPressed, state } from '../stores/uiStore';
 import { livedata } from '../stores/mlStore';
 import { t } from '../../i18n';
 import { get } from 'svelte/store';
@@ -40,6 +40,10 @@ class InputBehaviour extends LoggingDecorator {
 
   onIdentifiedAsMakecode(): void {
     super.onIdentifiedAsMakecode();
+    state.update(s => {
+      s.modelView = ModelView.TILE;
+      return s;
+    })
   }
 
   onGestureRecognized(id: number, gestureName: string): void {
@@ -96,7 +100,6 @@ class InputBehaviour extends LoggingDecorator {
       s.offerReconnect = false;
       s.isInputReady = false;
       s.reconnectState = DeviceRequestStates.NONE;
-      s.isInputMakecodeHex = false;
       return s;
     });
   }

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -63,7 +63,7 @@ class OutputBehaviour extends LoggingDecorator {
 
     state.update(s => {
       if (Microbits.isInputOutputTheSame()) {
-        s.modelView = Microbits.isOutputMakecode() ? ModelView.TILE : ModelView.STACK;
+        s.modelView = Microbits.isOutputMakecode() ? ModelView.TILE : s.modelView;
       }
 
       s.isOutputReady = true;
@@ -136,7 +136,6 @@ class OutputBehaviour extends LoggingDecorator {
     state.update(s => {
       s.isOutputConnected = false;
       s.isOutputReady = false;
-      s.modelView = ModelView.STACK;
       return s;
     });
   }


### PR DESCRIPTION
- Button to switch between Tile(makecode) and stack view is removed. It is now handled solely by detecting what HEX origin you use. I.e we swap the stack view for tile view when a HEX from makecode is detected.
- We no longer swap back in the stack view when makecode hex is disconnected, as reconnects makes the two views fight eachother
- Added button to go to makecode in the controlbar on the model page instead of the button in the lower right corner

I hope these changes makes it easier to work with, since I don't expect people to swap between these views regularly.

Next I will add capability to detect proprietary versions too, so that we always know where the hex came from