### PR TITLE
Changed character limit to 18

### DIFF
--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -30,7 +30,7 @@ class StaticConfiguration {
   public static readonly downloadedHexFilename = 'firmware.hex';
 
   // How long may gesture names be?
-  public static readonly gestureNameMaxLength = 25;
+  public static readonly gestureNameMaxLength = 18;
 
   // Default required confidence level
   public static readonly defaultRequiredConfidence = 0.8;

--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -145,7 +145,7 @@
 
   function onTitleKeypress(event: KeyboardEvent) {
     // Check backspace, delete and enter before alerting user, because we don't want to pop a warning when
-    // the user is at 25 characters, but is pressing enter.
+    // the user is at 18 characters, but is pressing enter.
     if (event.code === 'Backspace' || event.code === 'Delete') {
       return true;
     }
@@ -156,9 +156,15 @@
       }
       return true;
     }
+    
+    const selectedText = window.getSelection()?.toString();
+    if (selectedText && selectedText.length > 0) {
+      return true;
+    }
+
     if (gesture.name.length >= StaticConfiguration.gestureNameMaxLength) {
       event.preventDefault();
-      alertUser($t('alert.data.classNameLengthAlert'));
+      alertUser($t('alert.data.classNameLengthAlert', {"maxLen":StaticConfiguration.gestureNameMaxLength}));
       return false;
     }
   }

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -8,7 +8,7 @@ export default {
 	"da": { // APPROXIMATE SORTING ORDER: First alphabetically, then order of appearance from top to bottom of page
 		// ALERTS:
 		//In gesture.svelte 
-		"alert.data.classNameLengthAlert": "Navne må kun bestå af 25 tegn",
+		"alert.data.classNameLengthAlert": "Navne må kun bestå af {{maxLen}} tegn",
 		"alert.recording.disconnectedDuringRecording":"micro:bit frakoblede under optagelse",
 
 		//In common.js
@@ -258,7 +258,7 @@ export default {
 	"en": {
 		// ALERTS:
 		//In gesture.svelte
-		"alert.data.classNameLengthAlert": "Names must consists of maximum 25 characters.",
+		"alert.data.classNameLengthAlert": "Names must consists of maximum {{maxLen}} characters.",
 		"alert.recording.disconnectedDuringRecording":"micro:bit disconnected during recording",
 
 		//In common.js


### PR DESCRIPTION
- Limits the length of gesture names to 18. This is due to UART messages, as they are limited to 20 characters, and we use 2 for prefix to run the microbit extension
   - This does not mean it would be impossible to use more than 18 characters, but if we do we have to implement the ability to parse multiple messages of size at most 20, as these would be delivered in 20-byte chunks. Therefore it would be much simpler to just limit the length of the gesture names for now. The limit will be increased with #332 
- Fixes a bug that caused users to not be able to select and replace characters when entering a gesture name. Whenever users would enter a name for a gesture that was already at the limit, they would have to delete at least 1 character before they could replace the selected text with the incoming text
- Uses a translation variable to insert the max gesture name length into translation string