### PR TITLE
Timeout and progressbar for connection process

### DIFF
--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -15,6 +15,7 @@ import { HexOrigin } from './script/microbit-interfacing/Microbits';
 class StaticConfiguration {
   // in milliseconds, how long should be wait for reconnect before determining something catestrophic happened during the process?
   public static readonly reconnectTimeoutDuration: number = 7500;
+  public static readonly connectTimeoutDuration: number = 17000; // initial connection
 
   // After how long should we consider the connection lost if ping was not able to conclude?
   public static readonly connectionLostTimeoutDuration: number = 3000;

--- a/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
@@ -10,7 +10,7 @@
   import { t } from '../../../i18n';
   import { onDestroy, onMount } from 'svelte';
   import StandardButton from '../../StandardButton.svelte';
-  import { state } from '../../../script/stores/uiStore';
+  import { onCatastrophicError, state } from '../../../script/stores/uiStore';
   import {
     btPatternInput,
     btPatternOutput,
@@ -18,6 +18,8 @@
   import type { Writable } from 'svelte/store';
   import Microbits from '../../../script/microbit-interfacing/Microbits';
   import { DeviceRequestStates } from '../../../script/stores/connectDialogStore';
+    import Environment from '../../../script/Environment';
+    import StaticConfiguration from '../../../StaticConfiguration';
 
   // callbacks
   export let deviceState: DeviceRequestStates;
@@ -28,7 +30,10 @@
   let patternMatrixState: Writable<boolean[]> =
     deviceState === DeviceRequestStates.INPUT ? btPatternInput : btPatternOutput;
 
+  let timeoutProgress = 0;
+
   const connectButtonClicked = () => {
+    timeoutProgress = 0;
     if (isConnecting) {
       // Safeguard to prevent trying to connect multiple times at once
       return;
@@ -43,7 +48,20 @@
       }
     };
 
+    const interval = 50; // ms - Higher -> choppier animation. Lower -> smoother animation
+    const timeoutInterval = setInterval(() => {
+      timeoutProgress += interval / StaticConfiguration.connectTimeoutDuration;
+    }, interval);
+    const connectTimeout = setTimeout(() => {
+      clearInterval(timeoutInterval);
+      Environment.isInDevelopment && console.log("Connection timed out");
+      onCatastrophicError();
+    }, StaticConfiguration.connectTimeoutDuration);
+
     void connectionResult().then(didSucceed => {
+      clearTimeout(connectTimeout);
+      clearInterval(timeoutInterval);
+      Environment.isInDevelopment && console.log("Connection result ", didSucceed);
       if (didSucceed) {
         onBluetoothConnected();
       } else {
@@ -80,6 +98,7 @@
   <h1 class="mb-5 font-bold">
     {$t('popup.connectMB.bluetooth.heading')}
   </h1>
+
   {#if $state.requestDeviceWasCancelled && !isConnecting}
     <p class="text-warning mb-1">{$t('popup.connectMB.bluetooth.cancelledConnection')}</p>
   {/if}
@@ -88,6 +107,9 @@
     <div class="w-650px flex flex-col justify-center items-center">
       <p>{$t('popup.connectMB.bluetooth.connecting')}</p>
       <img alt="loading" src="/imgs/loadingspinner.gif" width="100px" />
+      <div class="bg-primary rounded w-full h-5">
+        <div style="width: {`${timeoutProgress * 100}%`};" class="bg-secondary rounded h-full"></div>
+      </div>
     </div>
   {:else}
     <div class="grid grid-cols-3 mb-5 w-650px">

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -177,17 +177,6 @@ class InputBehaviour extends LoggingDecorator {
       });
     }
   }
-
-  /**
-   * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
-   * Refresh the page is the only known solution
-   * @private
-   */
-  private onCatastrophicError() {
-    // Set flag to offer reconnect when page reloads
-    CookieManager.setReconnectFlag();
-    location.reload();
-  }
 }
 
 export default InputBehaviour;

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -5,7 +5,7 @@
  */
 
 import MicrobitBluetooth from '../microbit-interfacing/MicrobitBluetooth';
-import { ModelView, state } from '../stores/uiStore';
+import { ModelView, onCatastrophicError, state } from '../stores/uiStore';
 import { t } from '../../i18n';
 import { get } from 'svelte/store';
 import MBSpecs from '../microbit-interfacing/MBSpecs';
@@ -145,7 +145,7 @@ class OutputBehaviour extends LoggingDecorator {
 
     // Reset connection reconnectTimeoutTime
     clearTimeout(this.reconnectTimeout);
-    const onTimeout = () => this.onCatastrophicError();
+    const onTimeout = () => onCatastrophicError();
     this.reconnectTimeout = setTimeout(function () {
       onTimeout();
     }, StaticConfiguration.reconnectTimeoutDuration);
@@ -160,17 +160,6 @@ class OutputBehaviour extends LoggingDecorator {
       s.isOutputOutdated = false;
       return s;
     });
-  }
-
-  /**
-   * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
-   * Refresh the page is the only known solution
-   * @private
-   */
-  private onCatastrophicError() {
-    // Set flag to offer reconnect when page reloads
-    CookieManager.setReconnectFlag();
-    location.reload();
   }
 }
 

--- a/src/script/stores/uiStore.ts
+++ b/src/script/stores/uiStore.ts
@@ -12,6 +12,7 @@ import {
 import { t } from '../../i18n';
 import { gestures } from './mlStore';
 import { DeviceRequestStates } from './connectDialogStore';
+import CookieManager from '../CookieManager';
 
 // TODO: Rename? Split up further?
 
@@ -139,3 +140,13 @@ const initialMicrobitInteraction: MicrobitInteractions = MicrobitInteractions.AB
 export const microbitInteraction = writable<MicrobitInteractions>(
   initialMicrobitInteraction,
 );
+
+/**
+ * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
+ * Refresh the page is the only known solution
+ */
+export const onCatastrophicError = () => {
+  // Set flag to offer reconnect when page reloads
+  CookieManager.setReconnectFlag();
+  location.reload();
+}


### PR DESCRIPTION
When a user attempts to connect a microbit, a progress bar will be shown on the 'connecting' page of the connection prompt will fill over time. When the bar is full, the page will reload and a bluetooth error is assumed to have occured. 

Users have 17 seconds to either cancel, fulfill or fail a connection attempt, before the page reloads and reconnect prompt is offered. This duration can be configured in StaticConfiguration.ts

This is to hopefully lessen the impact of #325, where users could wait for a connection prompt that would never appear. This is meant as a temporary solution until a better strategy can be found to avoid this bug.

<img width="716" alt="image" src="https://github.com/microbit-foundation/cctd-ml-machine/assets/6570193/6c76c602-3edb-4e58-a1bf-a1c0b2cb3cbd">
