### PR TITLE
2 348 only show reconnect prompt if user have previously connected a microbit

### DIFF
--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -15,6 +15,7 @@ import { HexOrigin } from './script/microbit-interfacing/Microbits';
 class StaticConfiguration {
   // in milliseconds, how long should be wait for reconnect before determining something catestrophic happened during the process?
   public static readonly reconnectTimeoutDuration: number = 7500;
+  public static readonly connectTimeoutDuration: number = 17000; // initial connection
 
   // After how long should we consider the connection lost if ping was not able to conclude?
   public static readonly connectionLostTimeoutDuration: number = 3000;

--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -48,7 +48,7 @@ class StaticConfiguration {
     versionNumbers.set(HexOrigin.MAKECODE, 1);
     versionNumbers.set(HexOrigin.PROPRIETARY, 1);
     return versionNumbers.get(origin) !== version;
-  }
+  };
 
   public static readonly initialMLSettings = {
     duration: 1800,

--- a/src/__tests__/license-identifiers.test.ts
+++ b/src/__tests__/license-identifiers.test.ts
@@ -12,8 +12,8 @@ import 'jest-expect-message';
 import * as path from 'path';
 
 // Place files you wish to ignore by name in here
-const ignoredFiles: string[] = [".DS_Store"];
-const directoriesToScan = ['./src/', './microbit/v2/source/', './microbit/v1/source/']
+const ignoredFiles: string[] = ['.DS_Store'];
+const directoriesToScan = ['./src/', './microbit/v2/source/', './microbit/v1/source/'];
 
 const licenseIdentifierStringContributors =
   'Center for Computational Thinking and Design at Aarhus University and contributors';
@@ -79,12 +79,9 @@ describe('License identifier tests', () => {
   test(
     'All files should contain license identifier',
     () => {
-
-      const flatten = directoriesToScan.reduce(
-        (acc: any, current) => {
-          return acc.concat(flattenDirectory(current))
-        }, []
-      );
+      const flatten = directoriesToScan.reduce((acc: any, current) => {
+        return acc.concat(flattenDirectory(current));
+      }, []);
 
       const faultyFiles = filesMissingIdentifier(flatten, [
         licenseIdentifierStringContributors,
@@ -93,9 +90,9 @@ describe('License identifier tests', () => {
       expect(
         faultyFiles.length,
         'Some files do not contain identifier! ' +
-        faultyFiles
-          .map(val => `\n \u001b[35m${val} \u001b[0mis missing license identifier`)
-          .join(),
+          faultyFiles
+            .map(val => `\n \u001b[35m${val} \u001b[0mis missing license identifier`)
+            .join(),
       ).toEqual(0);
     },
     60000 * 10,

--- a/src/__tests__/microbit-facade.test.ts
+++ b/src/__tests__/microbit-facade.test.ts
@@ -62,7 +62,7 @@ describe('Microbit facade tests', () => {
   beforeEach(() => {
     try {
       Microbits.expelInputAndOutput();
-    } catch (_e) { }
+    } catch (_e) { /* empty */ }
   });
 
   test('Should give correct hex file', () => {

--- a/src/__tests__/mocks/SpyConnectionBehaviour.ts
+++ b/src/__tests__/mocks/SpyConnectionBehaviour.ts
@@ -48,7 +48,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     this.hasDisconnected = true;
   }
 
-  accelerometerChange(x: number, y: number, z: number): void { }
+  accelerometerChange(x: number, y: number, z: number): void {}
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string): void {
     this.hasConnected = true;
@@ -70,7 +70,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     }
   }
 
-  buttonChange(buttonState: MBSpecs.ButtonState, button: MBSpecs.Button): void { }
+  buttonChange(buttonState: MBSpecs.ButtonState, button: MBSpecs.Button): void {}
 
   isAssigned(): boolean {
     return false;
@@ -100,7 +100,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     return this.connectedName;
   }
 
-  onReady(): void { }
+  onReady(): void {}
 
   onBluetoothConnectionError(error?: unknown): void {
     this.hasFailedConnection = true;

--- a/src/__tests__/mocks/SpyConnectionBehaviour.ts
+++ b/src/__tests__/mocks/SpyConnectionBehaviour.ts
@@ -48,7 +48,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     this.hasDisconnected = true;
   }
 
-  accelerometerChange(x: number, y: number, z: number): void {}
+  accelerometerChange(x: number, y: number, z: number): void {/* Empty */}
 
   onAssigned(microbitBluetooth: MicrobitBluetooth, name: string): void {
     this.hasConnected = true;
@@ -70,7 +70,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     }
   }
 
-  buttonChange(buttonState: MBSpecs.ButtonState, button: MBSpecs.Button): void {}
+  buttonChange(buttonState: MBSpecs.ButtonState, button: MBSpecs.Button): void {/* Empty */}
 
   isAssigned(): boolean {
     return false;
@@ -100,7 +100,7 @@ class SpyConnectionBehaviour implements ConnectionBehaviour {
     return this.connectedName;
   }
 
-  onReady(): void {}
+  onReady(): void {/* Empty */}
 
   onBluetoothConnectionError(error?: unknown): void {
     this.hasFailedConnection = true;

--- a/src/__tests__/mocks/mock-bluetooth-gattservice.ts
+++ b/src/__tests__/mocks/mock-bluetooth-gattservice.ts
@@ -15,13 +15,13 @@ class MockBluetoothGattservice implements BluetoothRemoteGATTService {
     this.device = device;
   }
 
-  oncharacteristicvaluechanged(ev: Event): any { }
+  oncharacteristicvaluechanged(ev: Event): any {/* Empty */}
 
-  onserviceadded(ev: Event): any { }
+  onserviceadded(ev: Event): any {/* Empty */}
 
-  onservicechanged(ev: Event): any { }
+  onservicechanged(ev: Event): any {/* Empty */}
 
-  onserviceremoved(ev: Event): any { }
+  onserviceremoved(ev: Event): any {/* Empty */}
 
   addEventListener(
     type: 'serviceadded',
@@ -60,7 +60,7 @@ class MockBluetoothGattservice implements BluetoothRemoteGATTService {
       | EventListenerOrEventListenerObject
       | null,
     useCapture?: boolean | AddEventListenerOptions,
-  ): void { }
+  ): void {/* Empty */}
 
   dispatchEvent(event: Event): boolean;
   dispatchEvent(event: Event): boolean;
@@ -104,7 +104,7 @@ class MockBluetoothGattservice implements BluetoothRemoteGATTService {
     type: string,
     callback: EventListenerOrEventListenerObject | null,
     options?: EventListenerOptions | boolean,
-  ): void { }
+  ): void {/* Empty */}
 }
 
 export default MockBluetoothGattservice;

--- a/src/__tests__/mocks/mock-microbit-bluetooth.ts
+++ b/src/__tests__/mocks/mock-microbit-bluetooth.ts
@@ -15,8 +15,8 @@ class MockBTDevice implements BluetoothDevice {
   readonly id: string = '';
   readonly watchingAdvertisements: boolean = false;
   public gatt: BluetoothRemoteGATTServer;
-  public willFailConnection: boolean = false;
-  private microbitVersion: number = 0;
+  public willFailConnection = false;
+  private microbitVersion = 0;
   private listeners: DeviceListener[] = [];
 
   constructor() {
@@ -49,17 +49,17 @@ class MockBTDevice implements BluetoothDevice {
     return this;
   }
 
-  onadvertisementreceived(ev: BluetoothAdvertisingEvent): any { }
+  onadvertisementreceived(ev: BluetoothAdvertisingEvent): any {/* Empty */}
 
-  oncharacteristicvaluechanged(ev: Event): any { }
+  oncharacteristicvaluechanged(ev: Event): any {/* Empty */}
 
-  ongattserverdisconnected(ev: Event): any { }
+  ongattserverdisconnected(ev: Event): any {/* Empty */}
 
-  onserviceadded(ev: Event): any { }
+  onserviceadded(ev: Event): any {/* Empty */}
 
-  onservicechanged(ev: Event): any { }
+  onservicechanged(ev: Event): any {/* Empty */}
 
-  onserviceremoved(ev: Event): any { }
+  onserviceremoved(ev: Event): any {/* Empty */}
 
   addEventListener(
     type: 'gattserverdisconnected',
@@ -129,7 +129,7 @@ class MockBTDevice implements BluetoothDevice {
     type: string,
     callback: EventListenerOrEventListenerObject | null,
     options?: EventListenerOptions | boolean,
-  ): void { }
+  ): void {/* Empty */}
 
   watchAdvertisements(options?: WatchAdvertisementsOptions): Promise<void> {
     return Promise.resolve(undefined);
@@ -182,7 +182,9 @@ class MockGattServer implements BluetoothRemoteGATTServer {
     if (service === MBSpecs.Services.UART_SERVICE) {
       return Promise.resolve(new MockBluetoothGattservice(this.device));
     }
-    console.warn("The primary service, you tried to fetch were unknown. Was this on purpose?")
+    console.warn(
+      'The primary service, you tried to fetch were unknown. Was this on purpose?',
+    );
     return Promise.reject(undefined);
   }
 

--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -156,7 +156,7 @@
       }
       return true;
     }
-    
+
     const selectedText = window.getSelection()?.toString();
     if (selectedText && selectedText.length > 0) {
       return true;
@@ -164,7 +164,11 @@
 
     if (gesture.name.length >= StaticConfiguration.gestureNameMaxLength) {
       event.preventDefault();
-      alertUser($t('alert.data.classNameLengthAlert', {"maxLen":StaticConfiguration.gestureNameMaxLength}));
+      alertUser(
+        $t('alert.data.classNameLengthAlert', {
+          maxLen: StaticConfiguration.gestureNameMaxLength,
+        }),
+      );
       return false;
     }
   }

--- a/src/components/OutdatedMicrobitWarning.svelte
+++ b/src/components/OutdatedMicrobitWarning.svelte
@@ -13,23 +13,25 @@
 </script>
 
 {#if !hasBeenIgnored}
-<div
-  class="absolute top-8 right-4 bg-white rounded-md p-6 border-1 border-black z-5"
-  transition:horizontalSlide>
-  <div class="w-100">
-    <div class="absolute right-2 top-2 svelte-1rnkjvh">
-      <button on:click={() => hasBeenIgnored = true}
-        class="hover:bg-gray-100 rounded outline-transparent w-8 svelte-1rnkjvh">
-        <i
-          class="fas fa-plus text-lg text-gray-600 hover:text-gray-800 duration-75 svelte-1rnkjvh"
-          style="transform: rotate(45deg);" />
-      </button>
-    </div>
-    <p class="text-warning font-bold">{$t("popup.outdatedmicrobit.header")}</p>
-    <p>{$t("popup.outdatedmicrobit.text")}</p>
-    <div class="flex mt-5 justify-center">
-      <StandardButton onClick={() => hasBeenIgnored=true}>{$t("popup.outdatedmicrobit.button")}</StandardButton>
+  <div
+    class="absolute top-8 right-4 bg-white rounded-md p-6 border-1 border-black z-5"
+    transition:horizontalSlide>
+    <div class="w-100">
+      <div class="absolute right-2 top-2 svelte-1rnkjvh">
+        <button
+          on:click={() => (hasBeenIgnored = true)}
+          class="hover:bg-gray-100 rounded outline-transparent w-8 svelte-1rnkjvh">
+          <i
+            class="fas fa-plus text-lg text-gray-600 hover:text-gray-800 duration-75 svelte-1rnkjvh"
+            style="transform: rotate(45deg);" />
+        </button>
+      </div>
+      <p class="text-warning font-bold">{$t('popup.outdatedmicrobit.header')}</p>
+      <p>{$t('popup.outdatedmicrobit.text')}</p>
+      <div class="flex mt-5 justify-center">
+        <StandardButton onClick={() => (hasBeenIgnored = true)}
+          >{$t('popup.outdatedmicrobit.button')}</StandardButton>
+      </div>
     </div>
   </div>
-</div>
 {/if}

--- a/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
@@ -10,7 +10,7 @@
   import { t } from '../../../i18n';
   import { onDestroy, onMount } from 'svelte';
   import StandardButton from '../../StandardButton.svelte';
-  import { state } from '../../../script/stores/uiStore';
+  import { onCatastrophicError, state } from '../../../script/stores/uiStore';
   import {
     btPatternInput,
     btPatternOutput,
@@ -18,6 +18,8 @@
   import type { Writable } from 'svelte/store';
   import Microbits from '../../../script/microbit-interfacing/Microbits';
   import { DeviceRequestStates } from '../../../script/stores/connectDialogStore';
+    import Environment from '../../../script/Environment';
+    import StaticConfiguration from '../../../StaticConfiguration';
 
   // callbacks
   export let deviceState: DeviceRequestStates;
@@ -28,7 +30,10 @@
   let patternMatrixState: Writable<boolean[]> =
     deviceState === DeviceRequestStates.INPUT ? btPatternInput : btPatternOutput;
 
+  let timeoutProgress = 0;
+
   const connectButtonClicked = () => {
+    timeoutProgress = 0;
     if (isConnecting) {
       // Safeguard to prevent trying to connect multiple times at once
       return;
@@ -43,7 +48,20 @@
       }
     };
 
+    const interval = 50; // ms - Higher -> choppier animation. Lower -> smoother animation
+    const timeoutInterval = setInterval(() => {
+      timeoutProgress += interval / StaticConfiguration.connectTimeoutDuration;
+    }, interval);
+    const connectTimeout = setTimeout(() => {
+      clearInterval(timeoutInterval);
+      Environment.isInDevelopment && console.log("Connection timed out");
+      onCatastrophicError();
+    }, StaticConfiguration.connectTimeoutDuration);
+
     void connectionResult().then(didSucceed => {
+      clearTimeout(connectTimeout);
+      clearInterval(timeoutInterval);
+      Environment.isInDevelopment && console.log("Connection result ", didSucceed);
       if (didSucceed) {
         onBluetoothConnected();
       } else {
@@ -80,6 +98,7 @@
   <h1 class="mb-5 font-bold">
     {$t('popup.connectMB.bluetooth.heading')}
   </h1>
+
   {#if $state.requestDeviceWasCancelled && !isConnecting}
     <p class="text-warning mb-1">{$t('popup.connectMB.bluetooth.cancelledConnection')}</p>
   {/if}
@@ -88,6 +107,9 @@
     <div class="w-650px flex flex-col justify-center items-center">
       <p>{$t('popup.connectMB.bluetooth.connecting')}</p>
       <img alt="loading" src="/imgs/loadingspinner.gif" width="100px" />
+      <div class="bg-primary rounded w-full h-5">
+        <div style="width: {`${timeoutProgress * 100}%`};" class="bg-secondary rounded h-full"></div>
+      </div>
     </div>
   {:else}
     <div class="grid grid-cols-3 mb-5 w-650px">

--- a/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
@@ -18,8 +18,8 @@
   import type { Writable } from 'svelte/store';
   import Microbits from '../../../script/microbit-interfacing/Microbits';
   import { DeviceRequestStates } from '../../../script/stores/connectDialogStore';
-    import Environment from '../../../script/Environment';
-    import StaticConfiguration from '../../../StaticConfiguration';
+  import Environment from '../../../script/Environment';
+  import StaticConfiguration from '../../../StaticConfiguration';
 
   // callbacks
   export let deviceState: DeviceRequestStates;
@@ -54,14 +54,14 @@
     }, interval);
     const connectTimeout = setTimeout(() => {
       clearInterval(timeoutInterval);
-      Environment.isInDevelopment && console.log("Connection timed out");
+      Environment.isInDevelopment && console.log('Connection timed out');
       onCatastrophicError();
     }, StaticConfiguration.connectTimeoutDuration);
 
     void connectionResult().then(didSucceed => {
       clearTimeout(connectTimeout);
       clearInterval(timeoutInterval);
-      Environment.isInDevelopment && console.log("Connection result ", didSucceed);
+      Environment.isInDevelopment && console.log('Connection result ', didSucceed);
       if (didSucceed) {
         onBluetoothConnected();
       } else {
@@ -108,7 +108,9 @@
       <p>{$t('popup.connectMB.bluetooth.connecting')}</p>
       <img alt="loading" src="/imgs/loadingspinner.gif" width="100px" />
       <div class="bg-primary rounded w-full h-5">
-        <div style="width: {`${timeoutProgress * 100}%`};" class="bg-secondary rounded h-full"></div>
+        <div
+          style="width: {`${timeoutProgress * 100}%`};"
+          class="bg-secondary rounded h-full" />
       </div>
     </div>
   {:else}

--- a/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
@@ -14,6 +14,7 @@
   import {
     btPatternInput,
     btPatternOutput,
+    isInputPatternValid,
   } from '../../../script/stores/connectionStore';
   import type { Writable } from 'svelte/store';
   import Microbits from '../../../script/microbit-interfacing/Microbits';
@@ -27,12 +28,18 @@
 
   let isConnecting = false;
 
+  let attemptedToPairWithInvalidPattern = false;
+
   let patternMatrixState: Writable<boolean[]> =
     deviceState === DeviceRequestStates.INPUT ? btPatternInput : btPatternOutput;
 
   let timeoutProgress = 0;
 
   const connectButtonClicked = () => {
+    if (!isInputPatternValid()) {
+      attemptedToPairWithInvalidPattern = true;
+      return;
+    }
     timeoutProgress = 0;
     if (isConnecting) {
       // Safeguard to prevent trying to connect multiple times at once
@@ -79,6 +86,7 @@
 
   function updateMatrix(matrix: boolean[]): void {
     $patternMatrixState = matrix;
+    attemptedToPairWithInvalidPattern = false;
   }
 
   onMount(() => {
@@ -101,6 +109,9 @@
 
   {#if $state.requestDeviceWasCancelled && !isConnecting}
     <p class="text-warning mb-1">{$t('popup.connectMB.bluetooth.cancelledConnection')}</p>
+  {/if}
+  {#if attemptedToPairWithInvalidPattern}
+    <p class="text-warning mb-1">{$t('popup.connectMB.bluetooth.invalidPattern')}</p>
   {/if}
   {#if isConnecting}
     <!-- Show spinner while connecting -->

--- a/src/pages/filter/FilterGraph.svelte
+++ b/src/pages/filter/FilterGraph.svelte
@@ -6,8 +6,18 @@
 
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import {Chart, LinearScale, CategoryScale, ChartConfiguration, ChartData, LineElement, PointElement, LineController, Legend} from 'chart.js';
-  import {ViolinController, Violin} from '@sgratzl/chartjs-chart-boxplot';
+  import {
+    Chart,
+    LinearScale,
+    CategoryScale,
+    ChartConfiguration,
+    ChartData,
+    LineElement,
+    PointElement,
+    LineController,
+    Legend,
+  } from 'chart.js';
+  import { ViolinController, Violin } from '@sgratzl/chartjs-chart-boxplot';
   import { state } from '../../script/stores/uiStore';
   import { GestureData, gestures } from '../../script/stores/mlStore';
   import {
@@ -72,33 +82,43 @@
     }
     const prevData = getPrevData();
     // Return if insufficient amount of previous data is available
-    if( prevData === undefined ) return;
+    if (prevData === undefined) return;
     liveData = [
       filterFunction(prevData.x),
       filterFunction(prevData.y),
-      filterFunction(prevData.z)
+      filterFunction(prevData.z),
     ];
-      // TODO: Reconsider how to best update graph if values goes outside axes scales
+    // TODO: Reconsider how to best update graph if values goes outside axes scales
     data.datasets[0].data[0] = clamp(liveData[0], axisScale.min, axisScale.max);
     data.datasets[0].data[1] = clamp(liveData[1], axisScale.min, axisScale.max);
     data.datasets[0].data[2] = clamp(liveData[2], axisScale.min, axisScale.max);
     data.datasets[0].hidden = false;
     chart.update();
-  }
+  };
 
   onInterval(createLiveData, 100);
 
-function onInterval(callback: () => void, milliseconds: number) {
-	const interval = setInterval(callback, milliseconds);
-	onDestroy(() => {
-		clearInterval(interval);
-	});
-}
+  function onInterval(callback: () => void, milliseconds: number) {
+    const interval = setInterval(callback, milliseconds);
+    onDestroy(() => {
+      clearInterval(interval);
+    });
+  }
 
   const dataRepresentation = createFilteredData();
 
   function getColor(index: number): string {
-    const colors = ['#007bff', '#93003a', '#9a94ea', '#ce3664', '#f2778d', '#d0b2db', '#ffbcb8', '#ffffe0', '#f3d5d5'];
+    const colors = [
+      '#007bff',
+      '#93003a',
+      '#9a94ea',
+      '#ce3664',
+      '#f2778d',
+      '#d0b2db',
+      '#ffbcb8',
+      '#ffffe0',
+      '#f3d5d5',
+    ];
     return colors[index % colors.length];
   }
 
@@ -152,14 +172,10 @@ function onInterval(callback: () => void, milliseconds: number) {
     dataRepresentation.forEach((dataPoint, idx) => {
       data.datasets.push({
         itemRadius: 3,
-        itemBackgroundColor: getColor(idx) + "ff",
+        itemBackgroundColor: getColor(idx) + 'ff',
         label: dataPoint.name,
-        data: [
-          dataPoint.points.x,
-          dataPoint.points.y,
-          dataPoint.points.z,
-        ],
-        backgroundColor: forcedColor ?? getColor(idx) + "4D", // 4D is 30% opacity
+        data: [dataPoint.points.x, dataPoint.points.y, dataPoint.points.z],
+        backgroundColor: forcedColor ?? getColor(idx) + '4D', // 4D is 30% opacity
       });
     });
   };
@@ -178,7 +194,7 @@ function onInterval(callback: () => void, milliseconds: number) {
           radius: 3,
           pointStyle: 'point',
           backgroundColor: '#000000',
-        }
+        },
       },
       scales: {
         y: {
@@ -222,13 +238,20 @@ function onInterval(callback: () => void, milliseconds: number) {
   let chart: Chart;
   let canvas: HTMLCanvasElement;
   onMount(() => {
-    Chart.register(ViolinController, Violin, LinearScale, CategoryScale, LineElement, PointElement, LineController, Legend);
+    Chart.register(
+      ViolinController,
+      Violin,
+      LinearScale,
+      CategoryScale,
+      LineElement,
+      PointElement,
+      LineController,
+      Legend,
+    );
     if (canvas.getContext('2d') != null) {
       chart = new Chart(canvas.getContext('2d') ?? new HTMLCanvasElement(), config);
     }
   });
-
-
 </script>
 
 <canvas bind:this={canvas} id="myChart" />

--- a/src/pages/filter/FilterToggler.svelte
+++ b/src/pages/filter/FilterToggler.svelte
@@ -19,7 +19,7 @@
   $: isActive = $settings.includedFilters.has(filter);
 
   const toggleFilter = () => {
-    // Should be introduced again before pushed to production branch 
+    // Should be introduced again before pushed to production branch
     // settings.update(s => {
     //   if (s.includedFilters.has(filter)) {
     //     s.includedFilters.delete(filter);
@@ -41,8 +41,7 @@
       rounded-lg
       m-2
       relative
-      {isActive ? 'shadow-lg' : ''}"
-  >
+      {isActive ? 'shadow-lg' : ''}">
   <div class="filter flex justify-between">
     <div class="flex flex-row relative">
       <div class="absolute">

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -52,18 +52,18 @@
 <div class="flex flex-col h-full">
   <!-- Should be introduced again before pushed to production branch -->
   <!--{#if CookieManager.hasFeatureFlag('filters')} -->
-    <ControlBar>
-      <ExpandableControlBarMenu>
-        <StandardButton
-          small
-          outlined
-          onClick={() => {
-            navigate(Paths.FILTERS);
-          }}>
-          {$t('content.trainer.controlbar.filters')}
-        </StandardButton>
-      </ExpandableControlBarMenu>
-    </ControlBar>
+  <ControlBar>
+    <ExpandableControlBarMenu>
+      <StandardButton
+        small
+        outlined
+        onClick={() => {
+          navigate(Paths.FILTERS);
+        }}>
+        {$t('content.trainer.controlbar.filters')}
+      </StandardButton>
+    </ExpandableControlBarMenu>
+  </ControlBar>
   <!-- {/if} -->
   <div class="flex flex-col flex-grow justify-center items-center text-center">
     {#if !$state.isInputConnected}

--- a/src/script/Gestures.ts
+++ b/src/script/Gestures.ts
@@ -4,27 +4,29 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Writable, writable } from "svelte/store";
-import StaticConfiguration from "../StaticConfiguration";
+import { Writable, writable } from 'svelte/store';
+import StaticConfiguration from '../StaticConfiguration';
 
 class Gestures {
+  private static confidences: Map<number, Writable<number>> = new Map();
+  private static requiredConfidences: Map<number, Writable<number>> = new Map();
 
-    private static confidences: Map<number, Writable<number>> = new Map();
-    private static requiredConfidences: Map<number, Writable<number>> = new Map();
-
-    public static getConfidence(ID: number): Writable<number> {
-        if (!this.confidences.has(ID)) {
-            this.confidences.set(ID, writable(0));
-        }
-        return this.confidences.get(ID)!;
+  public static getConfidence(ID: number): Writable<number> {
+    if (!this.confidences.has(ID)) {
+      this.confidences.set(ID, writable(0));
     }
+    return this.confidences.get(ID)!;
+  }
 
-    public static getRequiredConfidence(ID: number): Writable<number> {
-        if (!this.requiredConfidences.has(ID)) {
-            this.requiredConfidences.set(ID, writable(StaticConfiguration.defaultRequiredConfidence));
-        }
-        return this.requiredConfidences.get(ID)!;
+  public static getRequiredConfidence(ID: number): Writable<number> {
+    if (!this.requiredConfidences.has(ID)) {
+      this.requiredConfidences.set(
+        ID,
+        writable(StaticConfiguration.defaultRequiredConfidence),
+      );
     }
+    return this.requiredConfidences.get(ID)!;
+  }
 }
 
 export default Gestures;

--- a/src/script/compatibility/CompatibilityChecker.ts
+++ b/src/script/compatibility/CompatibilityChecker.ts
@@ -40,9 +40,11 @@ export function checkCompatibility(): CompatibilityStatus {
   const majorVersion = browser.getBrowserVersion().split('.')[0];
   const minorVersion = browser.getBrowserVersion().split('.')[1];
   const semVer: SemVer = new SemVerImpl(majorVersion, minorVersion);
-  const isBluetoothSupported = navigator.bluetooth && BTComp.isVersionSupported(browserName, semVer, osName);
+  const isBluetoothSupported =
+    navigator.bluetooth && BTComp.isVersionSupported(browserName, semVer, osName);
 
-  const isUsbSupported = navigator.usb && USBComp.isVersionSupported(browserName, semVer, osName);
+  const isUsbSupported =
+    navigator.usb && USBComp.isVersionSupported(browserName, semVer, osName);
   let platformType = browser.getPlatform().type;
 
   // If platform won't report what it is, just assume desktop (ChromeOS doesnt report it)

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -43,7 +43,7 @@ class InputBehaviour extends LoggingDecorator {
     state.update(s => {
       s.isInputOutdated = true;
       return s;
-    })
+    });
   }
 
   onVersionIdentified(versionNumber: number): void {
@@ -55,7 +55,7 @@ class InputBehaviour extends LoggingDecorator {
     state.update(s => {
       s.modelView = ModelView.TILE;
       return s;
-    })
+    });
   }
 
   onIdentifiedAsProprietary(): void {

--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -177,17 +177,6 @@ class InputBehaviour extends LoggingDecorator {
       });
     }
   }
-
-  /**
-   * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
-   * Refresh the page is the only known solution
-   * @private
-   */
-  private onCatastrophicError() {
-    // Set flag to offer reconnect when page reloads
-    CookieManager.setReconnectFlag();
-    location.reload();
-  }
 }
 
 export default InputBehaviour;

--- a/src/script/connection-behaviours/LoggingDecorator.ts
+++ b/src/script/connection-behaviours/LoggingDecorator.ts
@@ -13,7 +13,6 @@ import Environment from '../Environment';
  * Used for logging / Decorator pattern
  */
 abstract class LoggingDecorator implements ConnectionBehaviour {
-
   private enableLogging: boolean = Environment.isInDevelopment && true;
 
   // For preventing spam of accelerometer data
@@ -25,7 +24,8 @@ abstract class LoggingDecorator implements ConnectionBehaviour {
   }
 
   onVersionIdentified(versionNumber: number): void {
-    this.enableLogging && console.log(`Microbit identified as version number ${versionNumber}`);
+    this.enableLogging &&
+      console.log(`Microbit identified as version number ${versionNumber}`);
   }
 
   onIdentifiedAsProprietary(): void {
@@ -41,7 +41,8 @@ abstract class LoggingDecorator implements ConnectionBehaviour {
   }
 
   onGestureRecognized(id: number, gestureName: string): void {
-    this.enableLogging && console.log(`Gesture '${gestureName}' with id ${id} was recognized`);
+    this.enableLogging &&
+      console.log(`Gesture '${gestureName}' with id ${id} was recognized`);
   }
 
   onUartMessageReceived(message: string): void {

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -36,7 +36,7 @@ class OutputBehaviour extends LoggingDecorator {
     state.update(s => {
       s.isOutputOutdated = true;
       return s;
-    })
+    });
   }
 
   onVersionIdentified(versionNumber: number): void {
@@ -57,7 +57,6 @@ class OutputBehaviour extends LoggingDecorator {
       return s;
     });
   }
-
 
   onIdentifiedAsProprietary(): void {
     super.onIdentifiedAsProprietary();

--- a/src/script/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/connection-behaviours/OutputBehaviour.ts
@@ -5,7 +5,7 @@
  */
 
 import MicrobitBluetooth from '../microbit-interfacing/MicrobitBluetooth';
-import { ModelView, state } from '../stores/uiStore';
+import { ModelView, onCatastrophicError, state } from '../stores/uiStore';
 import { t } from '../../i18n';
 import { get } from 'svelte/store';
 import MBSpecs from '../microbit-interfacing/MBSpecs';
@@ -145,7 +145,7 @@ class OutputBehaviour extends LoggingDecorator {
 
     // Reset connection reconnectTimeoutTime
     clearTimeout(this.reconnectTimeout);
-    const onTimeout = () => this.onCatastrophicError();
+    const onTimeout = () => onCatastrophicError();
     this.reconnectTimeout = setTimeout(function () {
       onTimeout();
     }, StaticConfiguration.reconnectTimeoutDuration);
@@ -160,17 +160,6 @@ class OutputBehaviour extends LoggingDecorator {
       s.isOutputOutdated = false;
       return s;
     });
-  }
-
-  /**
-   * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
-   * Refresh the page is the only known solution
-   * @private
-   */
-  private onCatastrophicError() {
-    // Set flag to offer reconnect when page reloads
-    CookieManager.setReconnectFlag();
-    location.reload();
   }
 }
 

--- a/src/script/microbit-interfacing/MBSpecs.ts
+++ b/src/script/microbit-interfacing/MBSpecs.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { isatty } from 'tty';
 import MicrobitBluetooth from './MicrobitBluetooth';
 
 /* eslint-disable @typescript-eslint/no-namespace */
@@ -269,7 +270,7 @@ namespace MBSpecs {
       return name;
     }
 
-    public static messageToDataview(message: string, delimiter: string = "#"): DataView {
+    public static messageToDataview(message: string, delimiter = '#'): DataView {
       if (delimiter.length != 1) {
         throw new Error('The delimiter must be 1 character long');
       }
@@ -304,6 +305,21 @@ namespace MBSpecs {
       }
 
       return code.join('');
+    }
+
+    public static isPairingPattermValid(pattern: boolean[]): boolean {
+      for (let col = 0; col < USBSpecs.MICROBIT_NAME_LENGTH; col++) {
+        let isAnyHighlighted = false;
+        for (let row = 0; row < USBSpecs.MICROBIT_NAME_LENGTH; row++) {
+          if (pattern[row * USBSpecs.MICROBIT_NAME_LENGTH + col]) {
+            isAnyHighlighted = true;
+          }
+        }
+        if (!isAnyHighlighted) {
+          return false;
+        }
+      }
+      return true;
     }
 
     /**

--- a/src/script/microbit-interfacing/MicrobitBluetooth.ts
+++ b/src/script/microbit-interfacing/MicrobitBluetooth.ts
@@ -162,10 +162,10 @@ export class MicrobitBluetooth {
 
   /**
    * Listen to the UART data transmission characteristic.
-   * 
+   *
    * Note: The limit for UART messages are 20 bytes. If messages larger than 20 bytes are
-   * received, they will trigger the given 'onDataReceived' multiple times  
-   * 
+   * received, they will trigger the given 'onDataReceived' multiple times
+   *
    * @param {(string) => void} onDataReceived Callback to be called when data is received.
    */
   public async listenToUART(onDataReceived: (data: string) => void): Promise<void> {

--- a/src/script/microbit-interfacing/Microbits.ts
+++ b/src/script/microbit-interfacing/Microbits.ts
@@ -26,10 +26,10 @@ type QueueElement = {
 export enum HexOrigin {
   UNKNOWN,
   MAKECODE,
-  PROPRIETARY
+  PROPRIETARY,
 }
 
-type UARTMessageType = "g" | "s"
+type UARTMessageType = 'g' | 's';
 
 /**
  * Entry point for microbit interfaces / Facade pattern
@@ -61,8 +61,10 @@ class Microbits {
   private static inputBuildVersion: number | undefined = undefined;
   private static outputBuildVersion: number | undefined = undefined;
 
-  private static inputVersionIdentificationTimeout: NodeJS.Timeout | undefined = undefined;
-  private static outputVersionIdentificationTimeout: NodeJS.Timeout | undefined = undefined;
+  private static inputVersionIdentificationTimeout: NodeJS.Timeout | undefined =
+    undefined;
+  private static outputVersionIdentificationTimeout: NodeJS.Timeout | undefined =
+    undefined;
 
   /**
    * Maps pin to the number of times, it has been asked to turn on.
@@ -242,10 +244,9 @@ class Microbits {
             this.inputName = name;
             Microbits.listenToOutputServices()
               .then(() => {
-                  clearTimeout(this.outputVersionIdentificationTimeout);
+                clearTimeout(this.outputVersionIdentificationTimeout);
                 connectionBehaviour.onReady();
                 ConnectionBehaviours.getOutputBehaviour().onReady();
-                
               })
               .catch(reason => {
                 console.log(reason);
@@ -319,9 +320,9 @@ class Microbits {
       'B',
       connectionBehaviour.buttonChange.bind(connectionBehaviour),
     );
-    await this.getInput().listenToUART((data) => this.inputUartHandler(data));
+    await this.getInput().listenToUART(data => this.inputUartHandler(data));
     this.inputVersionIdentificationTimeout = setTimeout(() => {
-        connectionBehaviour.onIdentifiedAsOutdated();
+      connectionBehaviour.onIdentifiedAsOutdated();
     }, StaticConfiguration.versionIdentificationTimeoutDuration);
   }
 
@@ -338,9 +339,9 @@ class Microbits {
       MBSpecs.Characteristics.UART_DATA_RX,
     );
     this.outputVersionIdentificationTimeout = setTimeout(() => {
-        connectionBehaviour.onIdentifiedAsOutdated();
+      connectionBehaviour.onIdentifiedAsOutdated();
     }, StaticConfiguration.versionIdentificationTimeoutDuration);
-    await this.getOutput().listenToUART((data) => this.outputUartHandler(data))
+    await this.getOutput().listenToUART(data => this.outputUartHandler(data));
   }
 
   /**
@@ -427,15 +428,15 @@ class Microbits {
 
   private static inputUartHandler(data: string) {
     const connectionBehaviour = ConnectionBehaviours.getInputBehaviour();
-    if (data === "id_mkcd") {
+    if (data === 'id_mkcd') {
       this.inputOrigin = HexOrigin.MAKECODE;
       connectionBehaviour.onIdentifiedAsMakecode();
     }
-    if (data === "id_prop") {
+    if (data === 'id_prop') {
       this.inputOrigin = HexOrigin.PROPRIETARY;
-      connectionBehaviour.onIdentifiedAsProprietary()
+      connectionBehaviour.onIdentifiedAsProprietary();
     }
-    if (data.includes("vi_")) {
+    if (data.includes('vi_')) {
       const version = parseInt(data.substring(3));
       this.inputBuildVersion = version;
       if (this.isInputOutputTheSame()) {
@@ -445,39 +446,39 @@ class Microbits {
       connectionBehaviour.onVersionIdentified(version);
       const isOutdated = StaticConfiguration.isMicrobitOutdated(
         this.inputOrigin,
-        version
-      )
+        version,
+      );
       if (isOutdated) {
         connectionBehaviour.onIdentifiedAsOutdated();
       }
     }
-    connectionBehaviour.onUartMessageReceived(data)
+    connectionBehaviour.onUartMessageReceived(data);
   }
 
   private static outputUartHandler(data: string) {
     const connectionBehaviour = ConnectionBehaviours.getOutputBehaviour();
-    if (data === "id_mkcd") {
+    if (data === 'id_mkcd') {
       this.outputOrigin = HexOrigin.MAKECODE;
       connectionBehaviour.onIdentifiedAsMakecode();
     }
-    if (data === "id_prop") {
+    if (data === 'id_prop') {
       this.outputOrigin = HexOrigin.PROPRIETARY;
-      connectionBehaviour.onIdentifiedAsProprietary()
+      connectionBehaviour.onIdentifiedAsProprietary();
     }
-    if (data.includes("vi_")) {
+    if (data.includes('vi_')) {
       clearTimeout(this.outputVersionIdentificationTimeout);
       const version = parseInt(data.substring(3));
       this.outputBuildVersion = version;
       connectionBehaviour.onVersionIdentified(version);
       const isOutdated = StaticConfiguration.isMicrobitOutdated(
         this.outputOrigin,
-        version
-      )
+        version,
+      );
       if (isOutdated) {
         connectionBehaviour.onIdentifiedAsOutdated();
       }
     }
-    connectionBehaviour.onUartMessageReceived(data)
+    connectionBehaviour.onUartMessageReceived(data);
   }
 
   private static onFailedConnection(behaviour: ConnectionBehaviour) {
@@ -719,14 +720,20 @@ class Microbits {
           ConnectionBehaviours.getOutputBehaviour().onIdentifiedAsProprietary();
         }
         if (this.outputBuildVersion) {
-          ConnectionBehaviours.getOutputBehaviour().onVersionIdentified(this.outputBuildVersion);
-          if (StaticConfiguration.isMicrobitOutdated(this.outputOrigin, this.outputBuildVersion)) {
+          ConnectionBehaviours.getOutputBehaviour().onVersionIdentified(
+            this.outputBuildVersion,
+          );
+          if (
+            StaticConfiguration.isMicrobitOutdated(
+              this.outputOrigin,
+              this.outputBuildVersion,
+            )
+          ) {
             ConnectionBehaviours.getOutputBehaviour().onIdentifiedAsOutdated();
           } else {
             clearTimeout(this.outputVersionIdentificationTimeout);
           }
         }
-        
       })
       .catch(e => {
         console.log(e);
@@ -814,7 +821,7 @@ class Microbits {
    */
   public static sendUARTGestureMessageToOutput(value: string) {
     if (!this.isOutputReady()) {
-      throw new Error("No output microbit is ready to receive UART gesture messages")
+      throw new Error('No output microbit is ready to receive UART gesture messages');
     }
     this.sendToOutputUart('g', value);
   }

--- a/src/script/ml.ts
+++ b/src/script/ml.ts
@@ -275,7 +275,8 @@ export function classify() {
 
   // Get formatted version of previous data
   const data = getPrevData();
-  if (data === undefined) throw new Error('Unsufficient amount of data to make prediction');
+  if (data === undefined)
+    throw new Error('Unsufficient amount of data to make prediction');
   const input: number[] = makeInputs(data);
   const inputTensor = tf.tensor([input]);
   const prediction: Tensor = get(model).predict(inputTensor) as Tensor;
@@ -297,7 +298,7 @@ function tfHandlePrediction(result: Float32Array) {
     Gestures.getConfidence(ID).update(val => {
       val = result[index];
       return val;
-    })
+    });
     gestureConfidences.update(confidenceMap => {
       confidenceMap[ID] = result[index];
       return confidenceMap;

--- a/src/script/stores/connectionStore.ts
+++ b/src/script/stores/connectionStore.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { type Writable } from 'svelte/store';
+import { get, type Writable } from 'svelte/store';
 import { persistantWritable } from './storeUtil';
+import MBSpecs from '../microbit-interfacing/MBSpecs';
 // Todo: Rename file to a more appropriate name
 // Pattern for connecting to input microbit
 export const btPatternInput: Writable<boolean[]> = persistantWritable<boolean[]>(
@@ -18,3 +19,8 @@ export const btPatternOutput: Writable<boolean[]> = persistantWritable<boolean[]
   'btPatternOutput',
   Array<boolean>(25).fill(false),
 );
+
+export const isInputPatternValid = () => {
+  const pattern = get(btPatternInput);
+  return MBSpecs.Utility.isPairingPattermValid(pattern);
+};

--- a/src/script/stores/mlStore.ts
+++ b/src/script/stores/mlStore.ts
@@ -291,10 +291,8 @@ export const trainingState = writable({
   epochs: 0,
 });
 
-
-
 // TODO: Only used at one location (ml.ts). Move to ml.ts?
-export function getPrevData(): { x: number[]; y: number[]; z: number[]} | undefined  {
+export function getPrevData(): { x: number[]; y: number[]; z: number[] } | undefined {
   const data: LiveData[] = get(prevData);
   const dataLength: number = data.length;
   // Returns undefined if there has not being collected minSamples data yet

--- a/src/script/stores/uiStore.ts
+++ b/src/script/stores/uiStore.ts
@@ -13,6 +13,7 @@ import { t } from '../../i18n';
 import { gestures } from './mlStore';
 import { DeviceRequestStates } from './connectDialogStore';
 import CookieManager from '../CookieManager';
+import { isInputPatternValid } from './connectionStore';
 
 // TODO: Rename? Split up further?
 
@@ -27,7 +28,7 @@ export const isBluetoothWarningDialogOpen = writable<boolean>(
 
 export enum ModelView {
   TILE,
-  STACK
+  STACK,
 }
 
 // Store current state to prevent error prone actions
@@ -147,6 +148,8 @@ export const microbitInteraction = writable<MicrobitInteractions>(
  */
 export const onCatastrophicError = () => {
   // Set flag to offer reconnect when page reloads
-  CookieManager.setReconnectFlag();
+  if (isInputPatternValid()) {
+    CookieManager.setReconnectFlag();
+  }
   location.reload();
-}
+};

--- a/src/script/stores/uiStore.ts
+++ b/src/script/stores/uiStore.ts
@@ -12,6 +12,7 @@ import {
 import { t } from '../../i18n';
 import { gestures } from './mlStore';
 import { DeviceRequestStates } from './connectDialogStore';
+import CookieManager from '../CookieManager';
 
 // TODO: Rename? Split up further?
 
@@ -139,3 +140,13 @@ const initialMicrobitInteraction: MicrobitInteractions = MicrobitInteractions.AB
 export const microbitInteraction = writable<MicrobitInteractions>(
   initialMicrobitInteraction,
 );
+
+/**
+ * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
+ * Refresh the page is the only known solution
+ */
+export const onCatastrophicError = () => {
+  // Set flag to offer reconnect when page reloads
+  CookieManager.setReconnectFlag();
+  location.reload();
+}

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -152,6 +152,7 @@ export default {
 		"popup.connectMB.bluetooth.step3": "Vælg din BBC micro:bit og tryk 'tilslut'.",
 		"popup.connectMB.bluetooth.connect": "Tilslut",
 		"popup.connectMB.bluetooth.connecting": "Tilslutter...",
+		"popup.connectMB.bluetooth.invalidPattern": "Mønstret du har tegnet er ikke gyldig",
 
 		"popup.disconnectedWarning.input": "Din input-micro:bit mistede forbindelsen, vil du prøve igen?",
 		"popup.disconnectedWarning.output": "Din output-micro:bit mistede forbindelsen, vil du prøve igen?",
@@ -403,6 +404,7 @@ export default {
 		"popup.connectMB.bluetooth.step3": "Select your micro:bit and press 'Connect'.",
 		"popup.connectMB.bluetooth.connect": "Connect",
 		"popup.connectMB.bluetooth.connecting": "Connecting...",
+		"popup.connectMB.bluetooth.invalidPattern": "The input pattern you drew is invalid",
 
 		"popup.disconnectedWarning.input": "Your input micro:bit lost connection, do want to try again?",
 		"popup.disconnectedWarning.output": "Your output micro:bit lost connection, do want to try again?",

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -404,7 +404,7 @@ export default {
 		"popup.connectMB.bluetooth.step3": "Select your micro:bit and press 'Connect'.",
 		"popup.connectMB.bluetooth.connect": "Connect",
 		"popup.connectMB.bluetooth.connecting": "Connecting...",
-		"popup.connectMB.bluetooth.invalidPattern": "The input pattern you drew is invalid",
+		"popup.connectMB.bluetooth.invalidPattern": "The pattern you drew is invalid",
 
 		"popup.disconnectedWarning.input": "Your input micro:bit lost connection, do want to try again?",
 		"popup.disconnectedWarning.output": "Your output micro:bit lost connection, do want to try again?",

--- a/src/views/OverlayView.svelte
+++ b/src/views/OverlayView.svelte
@@ -11,6 +11,7 @@
   import ReconnectPrompt from '../components/ReconnectPrompt.svelte';
   import ConnectionOfflineWarning from '../components/ConnectionOfflineWarning.svelte';
   import OutdatedMicrobitWarning from '../components/OutdatedMicrobitWarning.svelte';
+    import { isInputPatternValid } from '../script/stores/connectionStore';
 
   // Helps show error messages on top of page
   let latestMessage = '';
@@ -49,7 +50,7 @@
       </div>
     </div>
   {/if}
-  {#if $state.offerReconnect}
+  {#if $state.offerReconnect && isInputPatternValid()}
     <ReconnectPrompt />
   {/if}
   {#if $state.isInputOutdated || $state.isOutputOutdated}

--- a/src/views/OverlayView.svelte
+++ b/src/views/OverlayView.svelte
@@ -10,7 +10,7 @@
   import { message, state } from '../script/stores/uiStore';
   import ReconnectPrompt from '../components/ReconnectPrompt.svelte';
   import ConnectionOfflineWarning from '../components/ConnectionOfflineWarning.svelte';
-    import OutdatedMicrobitWarning from '../components/OutdatedMicrobitWarning.svelte';
+  import OutdatedMicrobitWarning from '../components/OutdatedMicrobitWarning.svelte';
 
   // Helps show error messages on top of page
   let latestMessage = '';


### PR DESCRIPTION
Builds on #347 Merge that first
- Runs linter and prettier on all files, adding semicolons, etc.
- Will no longer show reconnect prompt if no micro:bit name can be inferred by previous connections
    - This is mostly a theoretical edge-case, I doubt this problem has ever impacted a user
- You can no longer attempt to pair a micro:bit with an invalid pairing pattern. Attempting to do so yields the following message
<img width="717" alt="image" src="https://github.com/microbit-foundation/cctd-ml-machine/assets/6570193/d3688663-b073-4eb2-9eaf-feb055f5fc3c">