### PR TITLE
346 let users enable and disable data filters

### DIFF
--- a/src/StaticConfiguration.ts
+++ b/src/StaticConfiguration.ts
@@ -8,7 +8,6 @@
  * Static configuration values. These values are not expected to change, while the application is running.
  */
 import { PinTurnOnState } from './components/output/PinSelectorUtil';
-import { Axes, Filters, FilterType } from './script/datafunctions';
 import MBSpecs from './script/microbit-interfacing/MBSpecs';
 import { HexOrigin } from './script/microbit-interfacing/Microbits';
 
@@ -54,25 +53,5 @@ class StaticConfiguration {
     return versionNumbers.get(origin) !== version;
   };
 
-  public static readonly initialMLSettings = {
-    duration: 1800,
-    numSamples: 80,
-    minSamples: 80,
-    automaticClassification: true,
-    updatesPrSecond: 4,
-    numEpochs: 80,
-    learningRate: 0.5,
-    includedAxes: [Axes.X, Axes.Y, Axes.Z],
-    includedFilters: new Set<FilterType>([
-      Filters.MAX,
-      Filters.MEAN,
-      Filters.MIN,
-      Filters.STD,
-      Filters.PEAKS,
-      Filters.ACC,
-      Filters.ZCR,
-      Filters.RMS,
-    ]),
-  };
 }
 export default StaticConfiguration;

--- a/src/pages/filter/FilterPage.svelte
+++ b/src/pages/filter/FilterPage.svelte
@@ -21,17 +21,6 @@
 </script>
 
 <div>
-  <!-- <BaseDialog
-    isOpen={isFilterInspectorDialogOpen}
-    onClose={() => {
-      isFilterInspectorDialogOpen = false;
-    }}> 
-    <FilterInspector
-      filter={currentFilter}
-      onClose={() => {
-        isFilterInspectorDialogOpen = false;
-      }} />
-  </BaseDialog> -->
   <ControlBar>
   </ControlBar>
   {#if isFilterInspectorDialogOpen && currentFilter !== undefined}

--- a/src/pages/filter/FilterToggler.svelte
+++ b/src/pages/filter/FilterToggler.svelte
@@ -21,15 +21,14 @@
   $: isActive = $settings.includedFilters.has(filter);
 
   const toggleFilter = () => {
-    // Should be introduced again before pushed to production branch
-    // settings.update(s => {
-    //   if (s.includedFilters.has(filter)) {
-    //     s.includedFilters.delete(filter);
-    //   } else {
-    //     s.includedFilters.add(filter);
-    //   }
-    //   return s;
-    // });
+    settings.update(s => {
+      if (s.includedFilters.has(filter)) {
+        s.includedFilters.delete(filter);
+      } else {
+        s.includedFilters.add(filter);
+      }
+      return s;
+    });
   };
 </script>
 

--- a/src/script/stores/mlStore.ts
+++ b/src/script/stores/mlStore.ts
@@ -8,7 +8,7 @@ import { persistantWritable } from './storeUtil';
 import { get, writable } from 'svelte/store';
 import { LayersModel } from '@tensorflow/tfjs-layers';
 import { state } from './uiStore';
-import { AxesType, FilterType } from '../datafunctions';
+import { AxesType, FilterType, Axes, Filters } from '../datafunctions';
 import { PinTurnOnState } from '../../components/output/PinSelectorUtil';
 import MBSpecs from '../microbit-interfacing/MBSpecs';
 import StaticConfiguration from '../../StaticConfiguration';
@@ -105,8 +105,29 @@ type MlSettings = {
   includedFilters: Set<FilterType>;
 };
 
+const initialMLSettings: MlSettings = {
+  duration: 1800,
+  numSamples: 80,
+  minSamples: 80,
+  automaticClassification: true,
+  updatesPrSecond: 4,
+  numEpochs: 80,
+  learningRate: 0.5,
+  includedAxes: [Axes.X, Axes.Y, Axes.Z],
+  includedFilters: new Set<FilterType>([
+    Filters.MAX,
+    Filters.MEAN,
+    Filters.MIN,
+    Filters.STD,
+    Filters.PEAKS,
+    Filters.ACC,
+    Filters.ZCR,
+    Filters.RMS,
+  ]),
+};
+
 // Store with ML-Algorithm settings
-export const settings = writable<MlSettings>(StaticConfiguration.initialMLSettings);
+export const settings = persistantWritable<MlSettings>('MLSettings', initialMLSettings);
 
 export const gestures = persistantWritable<GestureData[]>('gestureData', []);
 

--- a/src/script/stores/storeUtil.ts
+++ b/src/script/stores/storeUtil.ts
@@ -24,7 +24,14 @@ export function persistantWritable<T>(key: string, initValue: T): Writable<T> {
 
   let storedObject: unknown;
   try {
-    storedObject = storedJson != null ? JSON.parse(storedJson) : null;
+    const parseSets = (key: string, value: unknown) => {
+      if (value instanceof Array && key === 'includedFilters') {
+        const setWithFilters = new Set(value);
+        return setWithFilters;
+      }
+      return value;
+    }
+    storedObject = storedJson != null ? JSON.parse(storedJson, parseSets) : null;
   } catch (error) {
     console.warn(error);
     storedObject = null;
@@ -36,8 +43,10 @@ export function persistantWritable<T>(key: string, initValue: T): Writable<T> {
     : initValue;
   const store: Writable<T> = writable(initValue);
   store.subscribe(val =>
-    localStorage.setItem(key, JSON.stringify({ version: persistVersion, value: val })),
-  );
+    localStorage.setItem(key, JSON.stringify({ version: persistVersion, value: val }, (key, value) => {
+      if (value instanceof Set && key === 'includedFilters') return [...value] as unknown[];
+      return value as unknown;
+    })));
 
   return store;
 }

--- a/src/script/stores/storeUtil.ts
+++ b/src/script/stores/storeUtil.ts
@@ -24,7 +24,7 @@ export function persistantWritable<T>(key: string, initValue: T): Writable<T> {
 
   let storedObject: unknown;
   try {
-    const parseSets = (key: string, value: unknown) => {
+    const parseSets = (key: string | number, value: unknown) => {
       if (value instanceof Array && key === 'includedFilters') {
         const setWithFilters = new Set(value);
         return setWithFilters;
@@ -43,9 +43,9 @@ export function persistantWritable<T>(key: string, initValue: T): Writable<T> {
     : initValue;
   const store: Writable<T> = writable(initValue);
   store.subscribe(val =>
-    localStorage.setItem(key, JSON.stringify({ version: persistVersion, value: val }, (key, value) => {
+    localStorage.setItem(key, JSON.stringify({ version: persistVersion, value: val }, (key: string | number, value: unknown) => {
       if (value instanceof Set && key === 'includedFilters') return [...value] as unknown[];
-      return value as unknown;
+      return value;
     })));
 
   return store;


### PR DESCRIPTION
I had to made some minor additions to the functions that parse the app state to json for the locale storage. The included filters-state is represented through a set, and sets are not parsed by JSON.Sringify() and JSON.parse().

I have added some code that transform the set into an array before it is stringified and back again to a set when the state is parsed to js objects.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify