### PR TITLE
Added a KNN model and KNN model trainer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-web": "^3.0.0",
+        "@tensorflow-models/knn-classifier": "^1.2.6",
         "@tensorflow/tfjs": "^4.4.0",
         "bowser": "^2.11.0",
         "browser-lang": "^0.2.1",
@@ -2700,6 +2701,15 @@
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@tensorflow-models/knn-classifier": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@tensorflow-models/knn-classifier/-/knn-classifier-1.2.6.tgz",
+      "integrity": "sha512-68RG9y70bFF0qYFpF+4bGaalAiEqz54v1qBmiSo3XODJq8Bow9EcDeAQBGPz6Bxiz6VQlZOdg29xiYm8N/a2Tw==",
+      "peerDependencies": {
+        "@tensorflow/tfjs-backend-cpu": "^4.10.0",
+        "@tensorflow/tfjs-core": "^4.10.0"
       }
     },
     "node_modules/@tensorflow/tfjs": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@microsoft/applicationinsights-web": "^3.0.0",
+    "@tensorflow-models/knn-classifier": "^1.2.6",
     "@tensorflow/tfjs": "^4.4.0",
     "bowser": "^2.11.0",
     "browser-lang": "^0.2.1",

--- a/src/components/playground/EngineInteractionButtons.svelte
+++ b/src/components/playground/EngineInteractionButtons.svelte
@@ -4,28 +4,17 @@
   SPDX-License-Identifier: MIT
  -->
 <script lang="ts">
-  import StaticConfiguration from '../../StaticConfiguration';
   import Gesture from '../../script/domain/Gesture';
-  import Model from '../../script/domain/Model';
   import AccelerometerClassifierInput from '../../script/mlmodels/AccelerometerClassifierInput';
-  import LayersModelTrainer from '../../script/mlmodels/LayersModelTrainer';
   import { classifier, engine, gestures } from '../../script/stores/Stores';
   import playgroundContext from './PlaygroundContext';
+  import TrainKnnModelButton from './TrainKNNModelButton.svelte';
+  import TrainLayersModelButton from './TrainLayersModelButton.svelte';
 
   const getRandomGesture = (): Gesture => {
     return gestures.getGestures()[
       Math.floor(Math.random() * gestures.getNumberOfGestures())
     ];
-  };
-
-  const model: Model = classifier.getModel();
-  const trainModelButtonClicked = () => {
-    playgroundContext.addMessage('training model...');
-    model
-      .train(new LayersModelTrainer(StaticConfiguration.layersModelTrainingSettings))
-      .then(() => {
-        playgroundContext.addMessage('Finished training!');
-      });
   };
 
   const predictButtonClicked = () => {
@@ -43,7 +32,8 @@
   };
 </script>
 
-<button class="border-1 p-2 m-1" on:click={trainModelButtonClicked}>train model!</button>
+<TrainLayersModelButton />
+<TrainKnnModelButton />
 <button class="border-1 p-2 m-1" on:click={predictButtonClicked}
   >Predict random gesture!</button>
 <button

--- a/src/components/playground/TrainKNNModelButton.svelte
+++ b/src/components/playground/TrainKNNModelButton.svelte
@@ -1,0 +1,22 @@
+<!--
+  (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ 
+  SPDX-License-Identifier: MIT
+ -->
+<script lang="ts">
+  import Model from '../../script/domain/Model';
+  import KNNModelTrainer from '../../script/mlmodels/KNNModelTrainer';
+  import { classifier } from '../../script/stores/Stores';
+  import playgroundContext from './PlaygroundContext';
+
+  const model: Model = classifier.getModel();
+  const trainModelButtonClicked = () => {
+    playgroundContext.addMessage('training model...');
+    model.train(new KNNModelTrainer()).then(() => {
+      playgroundContext.addMessage('Finished training!');
+    });
+  };
+</script>
+
+<button class="border-1 p-2 m-1" on:click={trainModelButtonClicked}
+  >train KNN model!</button>

--- a/src/components/playground/TrainKNNModelButton.svelte
+++ b/src/components/playground/TrainKNNModelButton.svelte
@@ -12,7 +12,8 @@
   const model: Model = classifier.getModel();
   const trainModelButtonClicked = () => {
     playgroundContext.addMessage('training model...');
-    model.train(new KNNModelTrainer(10)).then(() => {
+    const k = 10;
+    model.train(new KNNModelTrainer(k)).then(() => {
       playgroundContext.addMessage('Finished training a KNN model (k=10)!');
     });
   };

--- a/src/components/playground/TrainKNNModelButton.svelte
+++ b/src/components/playground/TrainKNNModelButton.svelte
@@ -12,8 +12,8 @@
   const model: Model = classifier.getModel();
   const trainModelButtonClicked = () => {
     playgroundContext.addMessage('training model...');
-    model.train(new KNNModelTrainer()).then(() => {
-      playgroundContext.addMessage('Finished training!');
+    model.train(new KNNModelTrainer(10)).then(() => {
+      playgroundContext.addMessage('Finished training a KNN model (k=10)!');
     });
   };
 </script>

--- a/src/components/playground/TrainKNNModelButton.svelte
+++ b/src/components/playground/TrainKNNModelButton.svelte
@@ -18,5 +18,6 @@
   };
 </script>
 
-<button class="border-1 p-2 m-1" on:click={trainModelButtonClicked}
-  >train KNN model!</button>
+<button class="border-1 p-2 m-1" on:click={trainModelButtonClicked}>
+  train KNN model!
+</button>

--- a/src/components/playground/TrainLayersModelButton.svelte
+++ b/src/components/playground/TrainLayersModelButton.svelte
@@ -1,0 +1,25 @@
+<!--
+  (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ 
+  SPDX-License-Identifier: MIT
+ -->
+<script lang="ts">
+  import StaticConfiguration from '../../StaticConfiguration';
+  import Model from '../../script/domain/Model';
+  import LayersModelTrainer from '../../script/mlmodels/LayersModelTrainer';
+  import { classifier } from '../../script/stores/Stores';
+  import playgroundContext from './PlaygroundContext';
+
+  const model: Model = classifier.getModel();
+  const trainModelButtonClicked = () => {
+    playgroundContext.addMessage('training model...');
+    model
+      .train(new LayersModelTrainer(StaticConfiguration.layersModelTrainingSettings))
+      .then(() => {
+        playgroundContext.addMessage('Finished training!');
+      });
+  };
+</script>
+
+<button class="border-1 p-2 m-1" on:click={trainModelButtonClicked}
+  >train layers model!</button>

--- a/src/components/playground/inputSynthesizer/AccelerometerDataSynthesizer.ts
+++ b/src/components/playground/inputSynthesizer/AccelerometerDataSynthesizer.ts
@@ -33,9 +33,8 @@ class AccelerometerSynthesizer implements Readable<AccelerometerSynthesizerData>
       xSpeed: this.getInitialSineSpeed(),
       ySpeed: this.getInitialSineSpeed() + 1 / 1000,
       zSpeed: this.getInitialSineSpeed() + 2 / 1000,
-      isActive: true,
+      isActive: false,
     });
-    this.updateInterval();
   }
 
   public subscribe(

--- a/src/script/mlmodels/KNNMLModel.ts
+++ b/src/script/mlmodels/KNNMLModel.ts
@@ -8,7 +8,10 @@ import MLModel from '../domain/MLModel';
 import * as knnClassifier from '@tensorflow-models/knn-classifier';
 
 class KNNMLModel implements MLModel {
-  constructor(private model: knnClassifier.KNNClassifier, private k: number) {}
+  constructor(
+    private model: knnClassifier.KNNClassifier,
+    private k: number,
+  ) {}
   public async predict(filteredData: number[]): Promise<number[]> {
     const inputTensor = tensor([filteredData]);
 

--- a/src/script/mlmodels/KNNMLModel.ts
+++ b/src/script/mlmodels/KNNMLModel.ts
@@ -8,13 +8,13 @@ import MLModel from '../domain/MLModel';
 import * as knnClassifier from '@tensorflow-models/knn-classifier';
 
 class KNNMLModel implements MLModel {
-  constructor(private model: knnClassifier.KNNClassifier) {}
+  constructor(private model: knnClassifier.KNNClassifier, private k: number) {}
   public async predict(filteredData: number[]): Promise<number[]> {
     const inputTensor = tensor([filteredData]);
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      const prediction = await this.model.predictClass(inputTensor);
+      const prediction = await this.model.predictClass(inputTensor, this.k);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const classes = Object.getOwnPropertyNames(prediction.confidences);
       const confidences: number[] = [];

--- a/src/script/mlmodels/KNNMLModel.ts
+++ b/src/script/mlmodels/KNNMLModel.ts
@@ -1,0 +1,37 @@
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { tensor } from '@tensorflow/tfjs';
+import MLModel from '../domain/MLModel';
+import * as knnClassifier from '@tensorflow-models/knn-classifier';
+
+class KNNMLModel implements MLModel {
+  constructor(private model: knnClassifier.KNNClassifier) {}
+  public async predict(filteredData: number[]): Promise<number[]> {
+    const inputTensor = tensor([filteredData]);
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      const prediction = await this.model.predictClass(inputTensor);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const classes = Object.getOwnPropertyNames(prediction.confidences);
+      const confidences: number[] = [];
+
+      for (let i = 0; i < classes.length; i++) {
+        const clazz = classes[i];
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        const confidence = prediction.confidences[clazz];
+        confidences.push(confidence as number);
+      }
+
+      return Promise.resolve(confidences);
+    } catch (err) {
+      console.error('Prediction error: ', err);
+      return Promise.reject(err);
+    }
+  }
+}
+
+export default KNNMLModel;

--- a/src/script/mlmodels/KNNModelTrainer.ts
+++ b/src/script/mlmodels/KNNModelTrainer.ts
@@ -8,7 +8,11 @@ import KNNMLModel from './KNNMLModel';
 import * as tf from '@tensorflow/tfjs';
 import * as knnClassifier from '@tensorflow-models/knn-classifier';
 
+/**
+ * Trains a K-Nearest Neighbour model
+ */
 class KNNModelTrainer implements ModelTrainer<KNNMLModel> {
+    constructor(private k: number) { }
   public trainModel(trainingData: TrainingData): Promise<KNNMLModel> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const knn: knnClassifier.KNNClassifier = knnClassifier.create();
@@ -21,7 +25,7 @@ class KNNModelTrainer implements ModelTrainer<KNNMLModel> {
       });
     });
 
-    return Promise.resolve(new KNNMLModel(knn));
+    return Promise.resolve(new KNNMLModel(knn, this.k));
   }
 }
 

--- a/src/script/mlmodels/KNNModelTrainer.ts
+++ b/src/script/mlmodels/KNNModelTrainer.ts
@@ -1,0 +1,28 @@
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import ModelTrainer, { TrainingData } from '../domain/ModelTrainer';
+import KNNMLModel from './KNNMLModel';
+import * as tf from '@tensorflow/tfjs';
+import * as knnClassifier from '@tensorflow-models/knn-classifier';
+
+class KNNModelTrainer implements ModelTrainer<KNNMLModel> {
+  public trainModel(trainingData: TrainingData): Promise<KNNMLModel> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const knn: knnClassifier.KNNClassifier = knnClassifier.create();
+
+    trainingData.classes.forEach((gestureClass, index) => {
+      gestureClass.samples.forEach(sample => {
+        const example = tf.tensor([sample.value]);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        knn.addExample(example, index);
+      });
+    });
+
+    return Promise.resolve(new KNNMLModel(knn));
+  }
+}
+
+export default KNNModelTrainer;

--- a/src/script/mlmodels/KNNModelTrainer.ts
+++ b/src/script/mlmodels/KNNModelTrainer.ts
@@ -12,7 +12,7 @@ import * as knnClassifier from '@tensorflow-models/knn-classifier';
  * Trains a K-Nearest Neighbour model
  */
 class KNNModelTrainer implements ModelTrainer<KNNMLModel> {
-    constructor(private k: number) { }
+  constructor(private k: number) {}
   public trainModel(trainingData: TrainingData): Promise<KNNMLModel> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const knn: knnClassifier.KNNClassifier = knnClassifier.create();


### PR DESCRIPTION
Adds a K-Nearest Neighbour ML model and a trainer for the model. See `KNNMLModel.ts` and `KNNModelTrainer.ts`.

```ts
 const trainModelButtonClicked = () => {
    const k = 10;
    model.train(new KNNModelTrainer(k)).then(() => {
        // Model finished training
    });
  };
```
```svelte
<button on:click={trainModelButtonClicked}>
  train KNN model!
</button>
```

Theres no UI to select it yet. However one can try it out by going to the playground and use the 'train KNN model' button to train one, then return to the model tab to see how well it works. Tip: Turn off the synthesizer before.

This prepares the next task #431 