### PR TITLE
Bugfix: Fixed hanging page bug

### DIFF
--- a/src/menus/ModelMenu.svelte
+++ b/src/menus/ModelMenu.svelte
@@ -12,12 +12,19 @@
 
   const bestPrediction = gestures.getBestPrediction();
 
-  $: confidence = $state.isInputReady
-    ? $bestPrediction.getConfidence().getCurrentConfidence()
-    : 0;
+  $: confidence =
+    $state.isInputReady && $bestPrediction
+      ? $bestPrediction.getConfidence().getCurrentConfidence()
+      : 0;
   confidence = isNaN(confidence) ? 0 : confidence;
 
-  const getPredictionLabel = (isInputReady: boolean, bestPrediction: Gesture) => {
+  const getPredictionLabel = (
+    isInputReady: boolean,
+    bestPrediction: Gesture | undefined,
+  ) => {
+    if (!bestPrediction) {
+      return $t('menu.model.noModel');
+    }
     if (!isInputReady) {
       return $t('menu.model.connectInputMicrobit');
     }

--- a/src/script/domain/stores/gesture/Gestures.ts
+++ b/src/script/domain/stores/gesture/Gestures.ts
@@ -100,10 +100,13 @@ class Gestures implements Readable<GestureData[]> {
     return get(Gestures.subscribableGestures).length;
   }
 
-  public getBestPrediction(): Readable<Gesture> {
+  public getBestPrediction(): Readable<Gesture | undefined> {
     return derived(
       get(Gestures.subscribableGestures).map(gest => gest.getConfidence()),
       confidences => {
+        if (confidences.length == 0) {
+          return undefined;
+        }
         const sorted = [...confidences].map((data, index) => {
           return {
             index: index,


### PR DESCRIPTION
Fixes a bug where attempting to access the model page without data would cause an exception. This was due to the page attempting to determine what the best prediction is to make a label for the left model menu, causing an index out of bound exception, since no confidences could be determined.