### PR TITLE
Added loss graph to visualize training

### DIFF
--- a/src/components/PleaseConnectFirst.svelte
+++ b/src/components/PleaseConnectFirst.svelte
@@ -16,17 +16,17 @@
 </script>
 
 <div>
-  <p class="text-center text-3xl bold m-auto">
+  <p class="text-center text-2xl bold m-auto">
     {$t('menu.trainer.notConnected1')}
   </p>
-  <p class="text-center text-3xl bold m-auto">
+  <p class="text-center text-2xl bold m-auto">
     {$t('menu.trainer.notConnected2')}
   </p>
-  <div class="text-center ml-auto mr-auto mb-2 mt-10">
+  <div class="text-center ml-auto mr-auto mb-2 mt-2">
     <img
       class="m-auto arrow-filter-color"
       src="/imgs/down_arrow.svg"
       alt="down arrow icon"
-      width="100px" />
+      width="50px" />
   </div>
 </div>

--- a/src/components/graphs/LossGraph.svelte
+++ b/src/components/graphs/LossGraph.svelte
@@ -1,0 +1,139 @@
+<!--
+  (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ 
+  SPDX-License-Identifier: MIT
+ -->
+
+<script lang="ts">
+  import {
+    Chart,
+    ChartConfiguration,
+    ChartTypeRegistry,
+    LineController,
+    LineElement,
+    LinearScale,
+    LogarithmicScale,
+    PointElement,
+    Title,
+    registerables,
+  } from 'chart.js';
+  import { t } from '../../i18n';
+
+  import { onMount } from 'svelte';
+  import { Readable } from 'svelte/store';
+  import { LossTrainingIteration } from './LossGraphUtil';
+
+  export let loss: Readable<LossTrainingIteration[]>;
+  export let maxX: number | undefined = undefined;
+
+  function getConfig(
+    data: { x: number; y: number }[],
+  ): ChartConfiguration<keyof ChartTypeRegistry, { x: number; y: number }[], string> {
+    return {
+      type: 'line',
+      data: {
+        datasets: [
+          {
+            label: 'x',
+            borderColor: 'red',
+            borderWidth: 1,
+            pointRadius: 0,
+            pointHoverRadius: 0,
+            data: data,
+          },
+        ],
+      },
+      options: {
+        //responsive: true,
+        //responsive: false,
+        plugins: {
+          title: {
+            display: true,
+            text: $t('content.trianer.lossGraph.title'),
+            padding: {
+              top: 10,
+              bottom: 30,
+            },
+          },
+        },
+        animation: false,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            type: 'linear',
+            min: 0,
+            max: maxX ? maxX : data.length,
+            grid: {
+              color: '#f3f3f3',
+            },
+            ticks: {
+              display: true,
+            },
+          },
+          y: {
+            type: 'logarithmic',
+            min: 0,
+            max: 1,
+            grid: {
+              color: '#f3f3f3',
+            },
+            ticks: {
+              display: true,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  $: {
+    const data: { x: number; y: number }[] = $loss.map(loss => {
+      return { x: loss.epoch, y: loss.loss };
+    });
+    drawChart(data);
+  }
+
+  let canvas: HTMLCanvasElement | undefined;
+  let chart: Chart | undefined;
+
+  const drawChart = (data: { x: number; y: number }[]) => {
+    if (!canvas) {
+      return undefined;
+    }
+    // if it has already been drawn, then destroy it first to redraw it
+    if (chart) {
+      chart.destroy();
+    }
+    Chart.unregister(...registerables);
+    Chart.register([
+      LinearScale,
+      LogarithmicScale,
+      LineController,
+      PointElement,
+      LineElement,
+      Title,
+    ]);
+    chart = new Chart(
+      canvas.getContext('2d') ?? new HTMLCanvasElement(),
+      getConfig(data),
+    );
+    chart.ctx.save();
+
+    return chart;
+  };
+
+  onMount(() => {
+    const data: { x: number; y: number }[] = $loss.map(loss => {
+      return { x: loss.epoch, y: loss.loss };
+    });
+    chart = drawChart(data);
+
+    return () => {
+      chart!.destroy();
+    };
+  });
+</script>
+
+<div class="h-60">
+  <canvas bind:this={canvas} />
+</div>

--- a/src/components/graphs/LossGraphUtil.ts
+++ b/src/components/graphs/LossGraphUtil.ts
@@ -1,0 +1,12 @@
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// TODO: Where to place this? It is used in the LayersModelTrainer, and maybe in other trainers in the future.
+//       It is primarily used by graph <LossGraph/> at the moment (28. feb 24)
+export type LossTrainingIteration = {
+  loss: number;
+  epoch: number;
+};

--- a/src/components/playground/TrainLayersModelButton.svelte
+++ b/src/components/playground/TrainLayersModelButton.svelte
@@ -14,7 +14,9 @@
   const trainModelButtonClicked = () => {
     playgroundContext.addMessage('training model...');
     model
-      .train(new LayersModelTrainer(StaticConfiguration.layersModelTrainingSettings))
+      .train(
+        new LayersModelTrainer(StaticConfiguration.layersModelTrainingSettings, () => {}),
+      )
       .then(() => {
         playgroundContext.addMessage('Finished training!');
       });

--- a/src/messages/ui.da.json
+++ b/src/messages/ui.da.json
@@ -63,6 +63,8 @@
   "content.trainer.failure.todo": "Gå tilbage til datasiden og ændr i din data.",
   "content.trainer.controlbar.filters": "Filtre",
 
+  "content.trianer.lossGraph.title": "Loss over tid",
+
   "content.filters.NoDataHeader": "Der er ikke noget data",
   "content.filters.NoDataBody": "Gå til Data-siden for at indsamle data.",
   "content.filters.max.title": "Maksværdier",

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -64,6 +64,8 @@
   "content.trainer.failure.todo": "Return to the data page and change your data.",
   "content.trainer.controlbar.filters": "Filters",
 
+  "content.trianer.lossGraph.title": "Loss over time",
+
   "content.filters.NoDataHeader": "No available data",
   "content.filters.NoDataBody": "Go to the Data page to collect data samples.",
   "content.filters.max.title": "Max values",

--- a/src/pages/training/TrainModelButton.svelte
+++ b/src/pages/training/TrainModelButton.svelte
@@ -17,6 +17,10 @@
   import MLModel from '../../script/domain/MLModel';
   import { Feature, hasFeature } from '../../script/FeatureToggles';
   import StandardButton from '../../components/buttons/StandardButton.svelte';
+  import { LossTrainingIteration } from '../../components/graphs/LossGraphUtil';
+
+  export let onTrainingIteration: (iteration: LossTrainingIteration) => void;
+  export let onClick: () => void;
 
   type ModelEntry = {
     id: string;
@@ -31,7 +35,9 @@
       title: 'Neural network',
       label: 'neural network',
       trainer: () =>
-        new LayersModelTrainer(StaticConfiguration.layersModelTrainingSettings),
+        new LayersModelTrainer(StaticConfiguration.layersModelTrainingSettings, h => {
+          onTrainingIteration(h);
+        }),
     },
     {
       id: 'KNN',
@@ -76,10 +82,11 @@
     'prefferedModel',
   );
 
-  const onClick = () => {
+  const clickHandler = () => {
     const selectedModel = availableModels.find(model => model.id === $selectedOption.id);
 
     if (selectedModel) {
+      onClick();
       model.train(selectedModel.trainer());
     }
   };
@@ -98,7 +105,7 @@
 
 {#if hasFeature(Feature.KNN_MODEL)}
   <StandardDropdownButton
-    {onClick}
+    onClick={clickHandler}
     {onSelect}
     buttonText={$t(trainButtonLabel, {
       values: { model: getModelFromOption($selectedOption).label },
@@ -106,7 +113,7 @@
     defaultOptionSelected={$selectedOption}
     {options} />
 {:else}
-  <StandardButton {onClick}>
+  <StandardButton onClick={clickHandler}>
     {$t(trainButtonSimpleLabel)}
   </StandardButton>
 {/if}

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -14,12 +14,28 @@
   import TrainModelButton from './TrainModelButton.svelte';
   import { classifier, gestures } from '../../script/stores/Stores';
   import StandardButton from '../../components/buttons/StandardButton.svelte';
+  import LossGraph from '../../components/graphs/LossGraph.svelte';
+  import { writable } from 'svelte/store';
+  import { LossTrainingIteration } from '../../components/graphs/LossGraphUtil';
+  import StaticConfiguration from '../../StaticConfiguration';
+  import CookieManager from '../../script/CookieManager';
 
   const model = classifier.getModel();
 
   const filters = classifier.getFilters();
 
   const sufficientData = gestures.hasSufficientData();
+
+  const loss = writable<LossTrainingIteration[]>([]);
+
+  const resetLoss = () => loss.set([]);
+
+  const trainingIterationHandler = (h: LossTrainingIteration) => {
+    loss.update(newLoss => {
+      newLoss.push(h);
+      return newLoss;
+    });
+  };
 </script>
 
 <TrainingFailedDialog />
@@ -48,39 +64,55 @@
           {$t('menu.trainer.notEnoughDataInfoBody')}
         </p>
       </div>
-    {:else if $model.isTraining}
-      <div class="w-3/4 text-primarytext">
-        <div class="ml-auto mr-auto flex center-items justify-center">
-          <i
-            class="fa fa-solid fa-circle-notch text-5xl animate-spin animate-duration-[2s]" />
-        </div>
-        <p class="bold text-3xl bold mt-10">
-          {$t('menu.trainer.isTrainingModelButton')}
-        </p>
-      </div>
     {:else}
       <div class="w-3/4 text-primarytext">
         {#if $model.isTrained}
-          <p class="bold text-3xl bold mt-10">
+          <p class="bold text-3xl bold mt-5">
             {$t('menu.trainer.TrainingFinished')}
           </p>
-          <p class="bold text-xl bold mt-10">
+          <p class="bold text-xl bold mt-5">
             {$t('menu.trainer.TrainingFinished.body')}
           </p>
         {/if}
-        {#if $filters.length == 0}
-          <p class="bold text-xl bold mt-10">
-            {$t('menu.trainer.noFilters')}
-          </p>
-        {:else}
-          <div class="w-full pt-5 text-white pb-5">
-            <TrainModelButton />
-          </div>
+        {#if $loss.length > 0 || $model.isTraining}
+          {#if !CookieManager.hasFeatureFlag('loss-graph')}
+            {#if $model.isTraining}
+              <div
+                class="flex flex-col flex-grow justify-center items-center text-center">
+                <div class="w-3/4 text-primarytext">
+                  <div class="ml-auto mr-auto flex center-items justify-center">
+                    <i
+                      class="fa fa-solid fa-circle-notch text-5xl animate-spin animate-duration-[2s]" />
+                  </div>
+                  <p class="bold text-3xl bold mt-10">
+                    {$t('menu.trainer.isTrainingModelButton')}
+                  </p>
+                </div>
+              </div>
+            {/if}
+          {:else}
+            <LossGraph
+              {loss}
+              maxX={StaticConfiguration.layersModelTrainingSettings.noOfEpochs} />
+          {/if}
+        {/if}
+        {#if !$model.isTraining}
+          {#if $filters.length == 0}
+            <p class="bold text-xl bold mt-10">
+              {$t('menu.trainer.noFilters')}
+            </p>
+          {:else}
+            <div class="w-full pt-5 text-white pb-5">
+              <TrainModelButton
+                onClick={resetLoss}
+                onTrainingIteration={trainingIterationHandler} />
+            </div>
+          {/if}
         {/if}
       </div>
     {/if}
     {#if !$state.isInputConnected}
-      <div class="mt-10">
+      <div class="mt-5">
         <PleaseConnectFirst />
       </div>
     {/if}


### PR DESCRIPTION
It is behind a feature flag. Create a cookie `fflags` and insert `loss-graph` as the value to enable (comma-separated for multiple values)

<img width="655" alt="image" src="https://github.com/microbit-foundation/cctd-ml-machine/assets/6570193/d05899c8-80f5-4282-8c29-528b73130ce4">


- Adds an onIteration function that can be handled. It will be supplied with the current epoch and what loss value it has reached
- Adds a chart.js line graph to visualize how loss changes as the model trains in real-time

**Thoughts**:
- Should we add some explanary texts to the page?
- Does the page become too cluttered with text? Maybe a restructuring is needed, especially with the KNN visualization
- Hasn't been tested with the KNN visualization, will probably run into some conflicts
- Adding buttons to change logarithmic/linear scales
- Since we can tap into the model at each iteration, we can compute accuracy in each iteration for a graph that may be easier to understand (this does take a lot of compute time though)
- Letting the users toy around with noOfEpochs, batchSize and learning rate could be introduced here
    -  If we do this, we could make the graph historic, saving the previous lines for comparison? 