### PR TITLE
Use azure insights to track when users train a model

### DIFF
--- a/src/appInsights.ts
+++ b/src/appInsights.ts
@@ -9,8 +9,10 @@ import CookieManager from './script/CookieManager';
 
 const load = () => {
   if (CookieManager.getComplianceChoices().analytics) {
+    console.log("Track data")
     appInsights.loadAppInsights();
     appInsights.trackPageView(); // Manually call trackPageView to establish the current user/session/pageview
+    appInsights.trackEvent({name: 'Test event'});
   }
 };
 const appInsights = new ApplicationInsights({

--- a/src/appInsights.ts
+++ b/src/appInsights.ts
@@ -9,13 +9,11 @@ import CookieManager from './script/CookieManager';
 
 const load = () => {
   if (CookieManager.getComplianceChoices().analytics) {
-    console.log("Track data")
     appInsights.loadAppInsights();
     appInsights.trackPageView(); // Manually call trackPageView to establish the current user/session/pageview
-    appInsights.trackEvent({name: 'Test event'});
   }
 };
-const appInsights = new ApplicationInsights({
+export const appInsights = new ApplicationInsights({
   config: {
     connectionString:
       'InstrumentationKey=9ff70ae9-1397-4b70-85f2-2d3e80a29113;IngestionEndpoint=https://northeurope-2.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/',

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -26,6 +26,7 @@
   import { LossTrainingIteration } from '../../components/graphs/LossGraphUtil';
   import StaticConfiguration from '../../StaticConfiguration';
   import CookieManager from '../../script/CookieManager';
+  import { appInsights } from '../../appInsights';
 
   const model = classifier.getModel();
 
@@ -49,6 +50,17 @@
       newLoss.push(h);
       return newLoss;
     });
+  };
+
+  const trackModelEvent = () => {
+    if (CookieManager.getComplianceChoices().analytics) {
+      appInsights.trackEvent({
+        name: 'ModelTrained',
+        properties: {
+          modelType: $selectedModelOption.id,
+        },
+      });
+    }
   };
 </script>
 
@@ -93,7 +105,7 @@
             <div class="w-full pt-5 text-white pb-5">
               <TrainModelButton
                 selectedOption={selectedModelOption}
-                onClick={resetLoss}
+                onClick={() => {resetLoss(); trackModelEvent();}}
                 onTrainingIteration={trainingIterationHandler} />
             </div>
           {/if}


### PR DESCRIPTION
This is a test of how we can use Azure app insights to track usage of the tool. If it works well, we can make more serious tracking of how users train models. 

We have to make sure that data from development activities and forked versions of the repository are not mixed with data from the ml-machine.org site. I will make a new issue on that.