### PR TITLE
Add no-name micro:bit connection

### DIFF
--- a/src/__tests__/microbit-bluetooth-connection.test.ts
+++ b/src/__tests__/microbit-bluetooth-connection.test.ts
@@ -170,16 +170,16 @@ describe('Microbit Bluetooth interface tests', () => {
 
   test('Request device yields device', async () => {
     const device = await MicrobitBluetooth.requestDevice(
-      'vatav',
       TypingUtils.emptyFunction,
+      'vatav',
     );
     expect(device).toBeDefined();
   });
 
   test('Can connect to requested device', async () => {
     const device = await MicrobitBluetooth.requestDevice(
-      'vatav',
       TypingUtils.emptyFunction,
+      'vatav',
     );
 
     const con = await MicrobitBluetooth.createMicrobitBluetooth(

--- a/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
@@ -127,11 +127,11 @@
   {#if $state.requestDeviceWasCancelled && !isConnecting}
     <p class="text-warning mb-1">{$t('popup.connectMB.bluetooth.cancelledConnection')}</p>
     <p class="text-warning mb-1">
-      Couldn't find your microbit on the list?
+      {$t('popup.connectMB.bluetooth.cancelledConnection.noNameDescription')}
       <span
         class="underline text-link cursor-pointer select-none"
         on:click={handleSearchWithoutName}>
-        Search for all nearby micro:bits
+        {$t('popup.connectMB.bluetooth.cancelledConnection.noNameLink')}
       </span>
     </p>
   {/if}

--- a/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectDialog.svelte
@@ -22,6 +22,7 @@
   import { DeviceRequestStates } from '../../../script/stores/connectDialogStore';
   import Environment from '../../../script/Environment';
   import StaticConfiguration from '../../../StaticConfiguration';
+  import Logger from '../../../script/utils/Logger';
 
   // callbacks
   export let deviceState: DeviceRequestStates;
@@ -70,7 +71,7 @@
     };
 
     const connectTimeout = setTimeout(() => {
-      Environment.isInDevelopment && console.log('Connection timed out');
+      Logger.log('BluetoothConnectDialog', 'Connection timed-out');
       timeouted.set(true);
     }, StaticConfiguration.connectTimeoutDuration);
 
@@ -78,7 +79,7 @@
       .then(didSucceed => {
         clearTimeout(connectTimeout);
         timeouted.set(false);
-        Environment.isInDevelopment && console.log('Connection result ', didSucceed);
+        Logger.log('BluetoothConnectDialog', 'Connection result:', didSucceed);
         if (didSucceed) {
           onBluetoothConnected();
         } else {

--- a/src/messages/ui.da.json
+++ b/src/messages/ui.da.json
@@ -1,17 +1,14 @@
 {
   "alert.data.classNameLengthAlert": "Navne må kun bestå af {maxLen} tegn",
   "alert.recording.disconnectedDuringRecording": "micro:bit frakoblede under optagelse",
-
   "alert.isRecording": "Du er i gang med at optage!",
   "alert.isTesting": "Du er i gang med at optage!",
   "alert.isTraining": "Du er i gang med at træne en model!",
   "alert.isNotConnected": "Din Micro:bit skal være tilsluttet!",
   "alert.deleteGestureConfirm": "Er du sikker på at du vil slette klassen ",
-
   "alert.twoGestures": "Du skal have mindst to klasser",
   "alert.oneDataRepresentation": "Du skal have mindst en data-repræsentation",
   "alert.recordingsPerGesture": "Du skal have mindst tre eksempler for hver klasse",
-
   "content.index.heading": "Gør-det-selv machine learning",
   "content.index.howBody": "Velkommen til 'ultra:bit datatræneren'. Eksperimentér og leg med machine learning og byg dine første machine learning-modeller – kom i gang her!",
   "content.index.ledDescription": "25 LED lys",
@@ -33,7 +30,6 @@
   "content.index.MLExplainer2": "For kunne dette laver ml-machine.org en datarepræsentation af eksemplerne ved at udregne specifikke egenskaber af hvert eksempel, fx standardafvigelse, samlet acceleration, den maximale værdi.",
   "content.index.MLExplainer3": "Data repræsentationerne af eksemplerne vises til et neuralt netværk. Det neurale netværk “lærer” fra disse eksempler ved at finde mønstre i og imellem eksemplerne.",
   "content.index.MLExplainer4": "Denne træningsprocess resulterer i et trænet neuralt netværk (vi kalder det også en machine learning model), der kan gætte/forudsige, hvordan micro:bit’en bevæges, når de samme egenskaber (standardafvigelse, samlet acceleration, den maximale værdi m.m.) beregnes fra det live accelerometer data.",
-
   "content.data.classPlaceholderNewClass": "Klik for at ændre navnet",
   "content.data.record": "Optag",
   "content.data.addData": "Tilføj data",
@@ -47,24 +43,19 @@
   "content.data.dataDescription": "Her kan du se din indsamlede data. Generelt vil det være en fordel at have mere data, da dette giver lærings-algoritmen mere infomration at lære ud fra.",
   "content.data.addDataNoConnection": "Du kan ikke tilføje data, uden at være tilsluttet en micro:bit",
   "content.data.noData": "Du har ingen bevægelser at træne med. Tilføj nogle bevægelser, som du vil træne din BBC micro:bit til at genkende.",
-
   "content.data.controlbar.button.clearData": "Ryd eksempler",
   "content.data.controlbar.button.clearData.confirm": "Er du sikker på at du vil slette alle eksempler?\nDette kan ikke fortrydes.",
   "content.data.controlbar.button.downloadData": "Download dataset",
   "content.data.controlbar.button.uploadData": "Upload dataset",
-
   "content.data.noData.templateDataButton": "Brug dataset eksempel",
   "content.data.noData.exampleName.shake": "Ryste",
   "content.data.noData.exampleName.still": "Stille",
   "content.data.noData.exampleName.circle": "Cirkel",
-
   "content.trainer.failure.header": "Træning mislykkedes",
   "content.trainer.failure.body": "Træningen resulterede ikke i en brugbar model. Grunden til dette ligger sandsynligvis i dataet. Hvis dataet i forskellige klasser minder for meget om hinanden, kan dette resultere i nogle forskellige problemer i træningsprocessen, der ikke gør det muligt at træne modellen ordentligt.",
   "content.trainer.failure.todo": "Gå tilbage til datasiden og ændr i din data.",
   "content.trainer.controlbar.filters": "Filtre",
-
   "content.trianer.lossGraph.title": "Loss over tid",
-
   "content.filters.NoDataHeader": "Der er ikke noget data",
   "content.filters.NoDataBody": "Gå til Data-siden for at indsamle data.",
   "content.filters.max.title": "Maksværdier",
@@ -83,7 +74,6 @@
   "content.filters.zcr.description": "Hvor ofte inputet (accelerationen) går fra positiv til negativ eller omvendt",
   "content.filters.rms.title": "Effektiv værdi ",
   "content.filters.rms.description": "Root mean square.",
-
   "content.model.trainModelFirstHeading": "Træn modellen først!",
   "content.model.trainModelFirstBody": "Gå til 'Træner'-siden",
   "content.model.classification.helpHeading": "Sandsynligheds-meteret",
@@ -94,39 +84,30 @@
   "content.model.output.soundOptionLoser": "Taber",
   "content.model.output.soundOptionMistake": "Fejl",
   "content.model.output.soundOptionHugeMistake": "Kæmpe fejl",
-
   "content.model.output.pin.option.allTime": "Altid tændt",
   "content.model.output.pin.option.xTime": "Tænd på tid",
   "content.model.output.pin.seconds": "Sekunder",
-
   "content.model.output.prediction.iconTitle": "Forudsigelse",
   "content.model.output.prediction.descriptionTitle": "Forudsigelse",
   "content.model.output.prediction.descriptionBody": "Her kan du se, hvilken klasse din model forudsiger den nuværende bevægelse til at være. Du kan se i meteret hvor sikker modellen er i sin forudsigelse.",
-
   "content.model.output.ledOutput.descriptionTitle": "LED output",
   "content.model.output.ledOutput.descriptionBody": "Her kan du vælge, hvordan LED-lysene på din output-micro:bit skal opføre sig, når din model forudsiger en klasse. Prøv at tegne nogle mønstre nedenfor og se, hvordan disse mønstre vises på din output-micro:bit, når du bevæger input-micro:bit'en.",
-
   "content.model.output.sound.iconTitle": "Lyd",
   "content.model.output.sound.descriptionTitle": "Afspilling af lyd",
   "content.model.output.sound.descriptionBody": "Her kan du vælge hvilken lyd din output-micro:bit skal afspille, når din model laver en forudsigelse. Bemærk at lyden afspilles af din computer, hvis du har en micro:bit version 1.",
-
   "content.model.output.pin.iconTitle": "Pin",
   "content.model.output.pin.descriptionTitle": "Pin output",
   "content.model.output.pin.descriptionBody": "Her kan du vælge hvilken pin skal tænde når modellen laver en forudsigelse på en bevægelse. Alle pins har numre i overenstemmelse med micro:bits officielle pin diagram.",
-
   "content.model.output.popup.header": "Tilslut output-micro:bit",
   "content.model.output.popup.body": "Hvis du ikke har tilsluttet en output-micro:bit, kan du ikke se resultatet af de ændringer du laver på denne side. Tilslut nedenfor.",
-
   "footer.connectButtonNotConnected": "Tilslut din BBC micro:bit",
   "footer.disconnectButton": "Frakobl",
   "footer.helpHeader": "Live graf",
   "footer.helpContent": "Når du har forbundet en micro:bit kan du live se Accelerometer-data for alle tre akser på denne graf. Prøv at bevæge din forbundende micro:bit og se, hvordan den data der produceres af bevægelserne ser ud for computeren!",
   "footer.reconnecting": "Genopretter forbindelsen. Vent venligst",
-
   "menu.data.helpHeading": "Data",
   "menu.data.helpBody": "For at træne en model til at genkende forskellige bevægelser, skal vi have gode eksempler på 'god opførsel', som vi kan vise træneren. Her kan i oprette klasser (en type bevægelse) og optage eksempler til hver klasse. Der skal være mindst 2 klasser med hver 3 eksempler før træneren kan træne en model.",
   "menu.data.examples": "eksempler",
-
   "menu.trainer.helpHeading": "Træner",
   "menu.trainer.helpBody": "Træneren kigger på eksemplerne i klasserne og forsøger at 'lære', hvordan de forskellige klasser kan genkendes ved at finde mønstre i dataet. Her kan i træne en model, der kan genkende forskellige bevægelser.",
   "menu.trainer.notConnected1": "Du har ikke tilkoblet en BBC micro:bit.",
@@ -142,18 +123,17 @@
   "menu.trainer.TrainingFinished.body": "Gå til Model-siden for at undersøge hvor godt din model virker",
   "menu.trainer.noFilters": "Du har ikke valgt nogle filtre. Der skal mindst være valgt 1 filter for at kunne træne en model",
   "menu.trainer.isTrainingModelButton": "Træner model...",
-
   "menu.model.helpHeading": "Model",
   "menu.model.helpBody": "Modellen kan bruges i et interaktivt system. Her bruger vi den trænede model til at forudsige bevægelser. Du kan tilslutte endnu en micro:bit og få den til at reagere på de bevægelser du laver.",
   "menu.model.noModel": "Ingen model",
   "menu.model.connectOutputButton": "Tilslut output-micro:bit",
   "menu.model.disconnect": "Frakobl output-micro:bit",
   "menu.model.connectInputMicrobit": "Tilkobl micro:bit",
-
   "popup.connectMB.main.bluetooth.subtitle": "Tilslut med Bluetooth",
-
   "popup.connectMB.bluetooth.heading": "Tilslut med Bluetooth",
   "popup.connectMB.bluetooth.cancelledConnection": "Du anullerede forbindelses-processen. Prøv igen hvis du ønsker at fortsætte.",
+  "popup.connectMB.bluetooth.cancelledConnection.noNameDescription": "Kunne du ikke finde den på listen?",
+  "popup.connectMB.bluetooth.cancelledConnection.noNameLink": "Søg efter micro:bit's i nærheden",
   "popup.connectMB.bluetooth.step0": "Tilslut et batteri til din BBC micro:bit",
   "popup.connectMB.bluetooth.step1": "Tegn mønstret du ser på BBC micro:bit'en",
   "popup.connectMB.bluetooth.step2": "Tryk på knappen nedenfor.",
@@ -162,21 +142,17 @@
   "popup.connectMB.bluetooth.connecting": "Tilslutter...",
   "popup.connectMB.bluetooth.invalidPattern": "Mønstret du har tegnet er ikke gyldig",
   "popup.connectMB.bluetooth.timeouted": "Dukker der ikke et forbind-vindue op? Prøv at indlæse siden igen.",
-
   "popup.disconnectedWarning.input": "Din input-micro:bit mistede forbindelsen, vil du prøve igen?",
   "popup.disconnectedWarning.output": "Din output-micro:bit mistede forbindelsen, vil du prøve igen?",
   "popup.disconnectedWarning.reconnectButton.input": "Tilslut input igen",
   "popup.disconnectedWarning.reconnectButton.output": "Tilslut output igen",
-
   "connectMB.main.usbHeader": "DOWNLOAD PROGRAM TIL BBC MICRO:BIT",
   "connectMB.main.btHeader": "TILSLUT DIN BBC MICRO:BIT VIA BLUETOOTH",
   "connectMB.main.usbBody": "Hvis du ikke tidligere har downloadet programmet",
   "connectMB.main.btBody": "Hvis du allerede har downloadet programmet",
   "connectMB.main.connectButton": "Tilslut",
   "connectMB.main.installButton": "Download",
-
   "connectMB.output.header": "En micro:bit er allerede forbundet",
-
   "connectMB.usb.header": "DOWNLOAD PROGRAM TIL BBC MICRO:BIT",
   "connectMB.usb.body1": "Tilslut din BBC micro:bit med USB-kabel og tryk på 'næste'",
   "connectMB.usb.body2": "Tryk 'Find USB-enhed' og vælg 'BBC micro:bit CMSIS-DAP' eller 'DAPLink CMSIS-DAP' fra popup-beskeden som kommer",
@@ -187,12 +163,10 @@
   "connectMB.usb.done.body2": "Du kan nu tilkoble dig via bluetooth.",
   "connectMB.usb.done.body3": "Hvis du har et batteri til din micro:bit kan du nu tage usb-kablet ud og tilslutte batteriet i stedet.",
   "connectMB.usb.done.body4": "Hvis du ikke har et batteri kan du fortsætte med at give din micro:bit strøm igennem usb-kablet.",
-
   "connectMB.usb.manual.header": "Overfør fil til din BBC microbit",
   "connectMB.usb.manual.manualDownload": "Hvis filen ikke downloadede automatisk tryk",
   "connectMB.usb.manual.manualDownloadLink": "her",
   "connectMB.usb.manual.done": "Færdig: Tilslut med bluetooth",
-
   "connectMB.usb.firmwareBroken.warning": "Vi opdagede en fejl med din micro:bit",
   "connectMB.usb.firmwareBroken.content1": "Din version af micro:bit og firmware har velkendte fejl, som forhindre os i at uploade programmet til din micro:bit.",
   "connectMB.usb.firmwareBroken.content2": "For at fortsætte nu skal du overføre programmet manuel eller opdatere din micro:bit",
@@ -200,12 +174,10 @@
   "connectMB.usb.firmwareBroken.content4": "Du kan finde en guide til hvordan du gør på ",
   "connectMB.usb.firmwareBroken.content4.website": "micro:bit fondens hjemmeside",
   "connectMB.usb.firmwareBroken.button.skip": "Spring over og overfør manuelt",
-
   "connectMB.outputMB.same": "Brug samme BBC micro:bit",
   "connectMB.outputMB.different": "Tilslut anden BBC micro:bit",
   "connectMB.outputMB.sameButton": "Samme",
   "connectMB.outputMB.otherButton": "Anden",
-
   "cookies.banner.title": "Cookie politik",
   "cookies.banner.subtitle": "Forbrug og analyse",
   "cookies.banner.text.pleaseHelp": "Hjælp os med at forbedre siden! Tillad cookies for at hjælpe os.",
@@ -214,43 +186,33 @@
   "cookies.banner.text.readMore.here": "her",
   "cookies.banner.buttons.reject": "Afvis",
   "cookies.banner.buttons.accept": "Accepter",
-
   "cookies.overlay.title": "Cookie politik",
-
   "cookies.overlay.question.whatAreCookies": "Hvad er cookies?",
   "cookies.overlay.question.ourReasoning": "Hvad bruger vi cookies til?",
   "cookies.overlay.question.storageDuration": "Hvor lang tid gemmer vi cookies?",
   "cookies.overlay.question.deleting": "Hvordan sletter man cookies?",
   "cookies.overlay.question.consentChange": "Hvordan ændrer jeg mit samtykke?",
-
   "cookies.overlay.answer.whatAreCookies": "Cookies er små filer med informationer, som der bliver gemt på den enhed du bruger til at browse med. Det er ikke programmer, som kan indeholder malware eller vira.",
   "cookies.overlay.answer.ourReasoning": "Vi bruger cookies for at indsamle information omkring forbrug af siden. Uden disse cookies er vi ikke i stand til at se hvordan vores side bliver brugt. Du gør derfor os en stor tjeneste ved at give samtykke til cookies.",
   "cookies.overlay.answer.storageDuration": "Det varier fra side til side og udnyttelsen af cookie'en. Nogle cookies bliver gemt indtil du forlader siden, andre bliver gemt i længere perioder. Alle vores cookies bliver gemt i et år.",
   "cookies.overlay.answer.deleting": "Det er forskelligt fra browser til browser. Her er dog en liste af manualer til de mest populære browsere.",
   "cookies.overlay.answer.consentChange": "På nuværende tidspunkt har du endnu ikke givet samtykke, men når du gør kan du blot slette din cookie, hvis du ønsker at trække samtykke tilbage eller på andenvis ombestemmer dig.",
-
   "cookies.overlay.table.title": "Cookies som vi bruger",
   "cookies.overlay.table.header.description": "Beskrivelse",
-
   "cookies.overlay.table.row.ai_user.description": "Brugt af Microsoft Application Insights til at indsamle statistisk data omkring forbrug. Den gemmer derudover et unik identifikationsnummer, som bruges til at genkende dig næste gang du amkommer på siden. Den gemmer ikke noget personligt omkring dig, og genererer et identifikationsnummer tilfældigt.",
   "cookies.overlay.table.row.ai_session.description": "Gemmer dit nuværende besøg, så vi kan genkende dig på tværs af vores sider.",
   "cookies.overlay.table.row.cookie_consent.description": "Gemmer dine samtykkevalg af vores cookie politik.",
-
   "popup.compatibility.bluetooth.header": "Browser ikke understøttet!",
   "popup.compatibility.bluetooth.explain": "Din nuværende browser understøtter ikke bluetooth. Bluetooth bruges til at drive siden. Uden det virker den ikke.",
   "popup.compatibility.bluetooth.advice": "Sikre at din browser er opdateret. Ellers kan du vælge en af de nedestående browsere, som understøtter bluetooth.",
-
   "popup.connectMB.USBCompatibility.transferStep.step1": "Åben placering af den firmware fil du lige har downloadet. Den findes oftest i din download mappe.",
   "popup.connectMB.USBCompatibility.transferStep.step2": "Træk filen over i micro:bit'en gennem din computers stifinder.",
   "popup.connectMB.USBCompatibility.transferStep.step3": "Når overførslen er færdig, kan du tilslutte din micro:bit med Bluetooth.",
-
   "compatibility.platform.notSupported": "Værktøjet er ikke understøttet på din nuværende platform.",
   "compatibility.platform.notSupported.joinDesktop": "Vi ses på computer.",
   "compatibility.webgl.notSupported": "WebGL er ikke tilgængelig. Aktiver WebGL for at se 3D data.",
-
   "dialog.connection.lost.header": "Forbindelse offline",
   "dialog.connection.lost.body": "Vi kan ikke oprette forbindelse til internettet, nogle funktioner virker muligvis ikke som forventet.",
-
   "popup.outdatedmicrobit.header": "Din micro:bit mangler en opdatering.",
   "popup.outdatedmicrobit.text": "Vi anbefaler stærkt at opdatere nu, nogle funktioner virker muligvis ikke som forventet.",
   "popup.outdatedmicrobit.text.mkcd": "Åben den nyeste MakeCode skabelon for at bruge den opdaterede MakeCode extension.",

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1,17 +1,14 @@
 {
   "alert.data.classNameLengthAlert": "Names must consists of maximum {maxLen} characters.",
   "alert.recording.disconnectedDuringRecording": "micro:bit disconnected during recording",
-
   "alert.isRecording": "You are currently recording!",
   "alert.isTesting": "You are currently recording!",
   "alert.isTraining": "You are currently training a model!",
   "alert.isNotConnected": "Your Micro:bit should be connected!",
   "alert.deleteGestureConfirm": "Are you sure you want to delete the class ",
-
   "alert.twoGestures": "You need at least two classes",
   "alert.oneDataRepresentation": "You need at least one data representation",
   "alert.recordingsPerGesture": "You need at least three examples per class",
-
   "content.index.heading": "Do It Yourself Machine Learning",
   "content.index.howBody": "Welcome to the ultra:bit data trainer. Experiment and play with machine larning and build your first machine learning models - start here!",
   "content.index.ledDescription": "25 LED lights",
@@ -33,7 +30,6 @@
   "content.index.MLExplainer2": "To achieve this, ml-machine.org  makes a data representation of the samples by calculating specific properties of each sample, such as standard deviation, cumulated acceleration, and maximum value.",
   "content.index.MLExplainer3": "The data representations of the data samples are shown to a neural network. The neural network “learns” from these examples by finding patterns in and between the samples.",
   "content.index.MLExplainer4": "This training process results in a trained neural network (we also call it a machine learning model) that can guess/predict how the micro:bit is moved when the same properties (standard deviation, cumulated acceleration, maximum value, etc.) are calculated from the live accelerometer data.",
-
   "content.data.classPlaceholderNewClass": "Press here to change name",
   "content.data.record": "Record",
   "content.data.addData": "Add Data",
@@ -44,28 +40,22 @@
   "content.data.choice": "Choice",
   "content.data.choice.header": "Choice of class",
   "content.data.choice.body": "Here, you choose which class you want to add data to. After having selected a class, you can either press the \"Record\" button below or press one of the buttons on your micro:bit to record a data segment. See the picture below.",
-
   "content.data.dataDescription": "Here you can see the gathered data. ",
   "content.data.addDataNoConnection": "You cannot add data without being connected with a micro:bit",
   "content.data.noData": "You do not have any gestures to train on. Add the gestures you wish the micro:bit should learn to recognise.",
-
   "content.data.controlbar.button.clearData": "Clear examples",
   "content.data.controlbar.button.clearData.confirm": "Are you sure you wish to delete all gesture examples?\nThis cannot be undone.",
   "content.data.controlbar.button.downloadData": "Download dataset",
   "content.data.controlbar.button.uploadData": "Upload dataset",
-
   "content.data.noData.templateDataButton": "Use example dataset",
   "content.data.noData.exampleName.shake": "Shake",
   "content.data.noData.exampleName.still": "Still",
   "content.data.noData.exampleName.circle": "Circle",
-
   "content.trainer.failure.header": "Training Failed",
   "content.trainer.failure.body": "The training did not result in a usable model. The reason for this is most likely the data used for training. If the data for different classes are too similar, this can result in issues in the training process.",
   "content.trainer.failure.todo": "Return to the data page and change your data.",
   "content.trainer.controlbar.filters": "Filters",
-
   "content.trianer.lossGraph.title": "Loss over time",
-
   "content.filters.NoDataHeader": "No available data",
   "content.filters.NoDataBody": "Go to the Data page to collect data samples.",
   "content.filters.max.title": "Max values",
@@ -84,7 +74,6 @@
   "content.filters.zcr.description": "The rate at which the input (acceleration) transitions between positive and negative.",
   "content.filters.rms.title": "Root mean square",
   "content.filters.rms.description": "",
-
   "content.model.trainModelFirstHeading": "Train the model first!",
   "content.model.trainModelFirstBody": "Go to the 'Trainer' page",
   "content.model.classification.helpHeading": "Probabil-ometer",
@@ -95,39 +84,30 @@
   "content.model.output.soundOptionLoser": "Loser",
   "content.model.output.soundOptionMistake": "Mistake",
   "content.model.output.soundOptionHugeMistake": "Huge Mistake",
-
   "content.model.output.pin.option.allTime": "Always on",
   "content.model.output.pin.option.xTime": "For time",
   "content.model.output.pin.seconds": "Seconds",
-
   "content.model.output.prediction.iconTitle": "Prediction",
   "content.model.output.prediction.descriptionTitle": "Prediction",
   "content.model.output.prediction.descriptionBody": "Here you can see the model's prediction of the current gesture. In the meter, you can see how confident the model is in the prediction.",
-
   "content.model.output.ledOutput.descriptionTitle": "LED output",
   "content.model.output.ledOutput.descriptionBody": "Here you can choose how the LEDs on your output micro:bit behaves when your model makes predictions. Try draw some patterns and see how they show on the output micro:bit when you move the input micro:bit.",
-
   "content.model.output.sound.iconTitle": "Sound",
   "content.model.output.sound.descriptionTitle": "Playback of sound",
   "content.model.output.sound.descriptionBody": "Here you can choose which sound you output micro:bit plays when the model makes a prediction. Be aware that the sound plays from your computer if you have a micro:bit version 1.",
-
   "content.model.output.pin.iconTitle": "Pin",
   "content.model.output.pin.descriptionTitle": "Pin outputs",
   "content.model.output.pin.descriptionBody": "Here you can select which pin will turn on when a gesture is predicted. Each pins are numbered according to micro:bit's official pin output diagram.",
-
   "content.model.output.popup.header": "Connect output micro:bit",
   "content.model.output.popup.body": "If you have not connected an output micro:bit, you cannot see the results of the changed made on this page. Use the connect button below",
-
   "footer.connectButtonNotConnected": "Connect your micro:bit",
   "footer.disconnectButton": "Disconnect",
   "footer.helpHeader": "Live graph",
   "footer.helpContent": "Once you have connected a micro:bit you can watch the accelerometer data for all three axes on this graph in real time. Try moving your connected micro:bit to see what the data looks like to your computer!",
   "footer.reconnecting": "Reconnecting. Please wait",
-
   "menu.data.helpHeading": "Data",
   "menu.data.helpBody": "In order to train a model to recognize different movements, we need good examples of 'good behavior' that we can show the Trainer. Here you can create classes (types of gestures) and record examples for each class. There must be at least 2 classes with 3 examples each before the trainer can train a model.",
   "menu.data.examples": "examples",
-
   "menu.trainer.helpHeading": "Trainer",
   "menu.trainer.helpBody": "The Trainer looks at the examples in each of the classes and tries to 'learn' how the different classes can be recognized by searching for patterns in the data. Here you can train a model to recognize different gestures.",
   "menu.trainer.notConnected1": "You have not connected a micro:bit.",
@@ -143,18 +123,17 @@
   "menu.trainer.TrainingFinished.body": "Go to the Model-page to examine how well your model works",
   "menu.trainer.noFilters": "No filters have been selected. You must enable at least 1 filter in order to train a model",
   "menu.trainer.isTrainingModelButton": "Training model",
-
   "menu.model.helpHeading": "Model",
   "menu.model.helpBody": "The model can be used in an interactive system. Here we use the trained model to predict gestures. You can connect another micro:bit and make it respond to the predicted gestures.",
   "menu.model.noModel": "No model",
   "menu.model.connectOutputButton": "Connect output micro:bit",
   "menu.model.disconnect": "Disconnect output micro:bit",
   "menu.model.connectInputMicrobit": "Connect micro:bit",
-
   "popup.connectMB.main.bluetooth.subtitle": "Connect using Bluetooth",
-
   "popup.connectMB.bluetooth.heading": "Connect using Bluetooth",
   "popup.connectMB.bluetooth.cancelledConnection": "You cancelled the connection process. Try again, if you wish to proceed.",
+  "popup.connectMB.bluetooth.cancelledConnection.noNameDescription": "Couldn't find your micro:bit on the list?",
+  "popup.connectMB.bluetooth.cancelledConnection.noNameLink": "Search for all nearby micro:bits",
   "popup.connectMB.bluetooth.step0": "Connect your micro:bit to a battery",
   "popup.connectMB.bluetooth.step1": "Draw the pattern as displayed on the micro:bit",
   "popup.connectMB.bluetooth.step2": "Press the 'Connect' button below.",
@@ -163,21 +142,17 @@
   "popup.connectMB.bluetooth.connecting": "Connecting...",
   "popup.connectMB.bluetooth.invalidPattern": "The pattern you drew is invalid",
   "popup.connectMB.bluetooth.timeouted": "Not seeing a connection prompt? Try refreshing the page.",
-
   "popup.disconnectedWarning.input": "Your input micro:bit lost connection, do want to try again?",
   "popup.disconnectedWarning.output": "Your output micro:bit lost connection, do want to try again?",
   "popup.disconnectedWarning.reconnectButton.input": "Reconnect input",
   "popup.disconnectedWarning.reconnectButton.output": "Reconnect output",
-
   "connectMB.main.usbHeader": "DOWNLOAD PROGRAM TO MICRO:BIT",
   "connectMB.main.btHeader": "CONNECT YOUR MICRO:BIT USING BLUETOOTH",
   "connectMB.main.usbBody": "If you have not previously downloaded the program",
   "connectMB.main.btBody": "If you have already downloaded the program",
   "connectMB.main.connectButton": "Connect",
   "connectMB.main.installButton": "Download",
-
   "connectMB.output.header": "A micro:bit is already connected",
-
   "connectMB.usb.header": "DOWNLOAD PROGRAM TO MICRO:BIT",
   "connectMB.usb.body1": "Connect your micro:bit using a USB-cable and click 'Next'",
   "connectMB.usb.body2": "Click 'Find USB unit' and select 'BBC micro:bit CMSIS-DAP' or 'DAPLink CMSIS-DAP' from the popup that appears",
@@ -188,12 +163,10 @@
   "connectMB.usb.done.body2": "You can now connect through bluetooth.",
   "connectMB.usb.done.body3": "If you have a battery for the micro:bit, you can now remove the usb-cable and use the battery instead.",
   "connectMB.usb.done.body4": "If you do not have a battery for the micro:bit, you can simply keep powering it through the usb cable.",
-
   "connectMB.usb.manual.header": "Transfer file to your micro:bit",
   "connectMB.usb.manual.manualDownload": "If the file did not automatically download press",
   "connectMB.usb.manual.manualDownloadLink": "here",
   "connectMB.usb.manual.done": "Done: Connect using bluetooth",
-
   "connectMB.usb.firmwareBroken.warning": "We detected issues with your micro:bit firmware",
   "connectMB.usb.firmwareBroken.content1": "The version of micro:bit and firmware have known issues, that prevent us from uploading the program to it.",
   "connectMB.usb.firmwareBroken.content2": "To proceed, you will have to transfer manually, or update your micro:bit's firmware.",
@@ -201,12 +174,10 @@
   "connectMB.usb.firmwareBroken.content4": "A guide on how can be found on the ",
   "connectMB.usb.firmwareBroken.content4.website": "micro:bit foundation's website",
   "connectMB.usb.firmwareBroken.button.skip": "Skip and transfer manually",
-
   "connectMB.outputMB.same": "Use the same micro:bit",
   "connectMB.outputMB.different": "Connect another micro:bit",
   "connectMB.outputMB.sameButton": "Same",
   "connectMB.outputMB.otherButton": "Other",
-
   "cookies.banner.title": "Cookie policy",
   "cookies.banner.subtitle": "Performance & analytics",
   "cookies.banner.text.pleaseHelp": "Please help us make it better by keeping the cookies enabled.",
@@ -215,43 +186,33 @@
   "cookies.banner.text.readMore.here": "here",
   "cookies.banner.buttons.reject": "Reject",
   "cookies.banner.buttons.accept": "Accept",
-
   "cookies.overlay.title": "Cookie policy",
-
   "cookies.overlay.question.whatAreCookies": "What are cookies?",
   "cookies.overlay.question.ourReasoning": "What do we use cookies for?",
   "cookies.overlay.question.storageDuration": "For how long are cookies stored?",
   "cookies.overlay.question.deleting": "How do i delete cookies?",
   "cookies.overlay.question.consentChange": "How do i change my consent?",
-
   "cookies.overlay.answer.whatAreCookies": "Cookies are small data files stored on the device you are using to browse websites. They are not programs, that contain harmful malware or viruses.",
   "cookies.overlay.answer.ourReasoning": "We use cookies to collect information on the usage and performance of the website. Without these cookies, we will not be able to collect vital information on the performance of the site.",
   "cookies.overlay.answer.storageDuration": "It varies from site to site and the usage of the cookie. Some may be stored for only the current session, while others may be stored for days. Our cookies are stored for one year.",
   "cookies.overlay.answer.deleting": "It varies from browser to browser. However here are some of the manuals for some of the most commonly used browsers.",
   "cookies.overlay.answer.consentChange": "Currently, you have not rejected nor agreed to our cookie policy. But once you do, you will be able to delete cookies to change your consent at any time.",
-
   "cookies.overlay.table.title": "The cookies we use",
   "cookies.overlay.table.header.description": "Description",
-
   "cookies.overlay.table.row.ai_user.description": "Used by Microsoft Application Insights software to collect statistical usage and telemetry information. The cookie stores a unique identifier to recognise users on returning visits over time.",
   "cookies.overlay.table.row.ai_session.description": "Preserves users states across page requests.",
   "cookies.overlay.table.row.cookie_consent.description": "Stores the terms to which you have given consent to in regards to our cookie policy.",
-
   "popup.compatibility.bluetooth.header": "Bluetooth incompatible browser!",
   "popup.compatibility.bluetooth.explain": "The browser you are currently using does not support bluetooth.",
   "popup.compatibility.bluetooth.advice": "Please update the browser or use another one from our supported browsers list below.",
-
   "popup.connectMB.USBCompatibility.transferStep.step1": "Open the location to which the firmware was downloaded. Most commonly found in your download folder.",
   "popup.connectMB.USBCompatibility.transferStep.step2": "Drag the file onto the micro:bit on your computer's file explorer.",
   "popup.connectMB.USBCompatibility.transferStep.step3": "Once the file has finished transferring, the micro:bit can be connected using Bluetooth.",
-
   "compatibility.platform.notSupported": "The tool is not supported on your current platform.",
   "compatibility.platform.notSupported.joinDesktop": "Join us on desktop.",
   "compatibility.webgl.notSupported": "WebGL not available. Enable WebGL to see 3D data view.",
-
   "dialog.connection.lost.header": "Connection offline",
   "dialog.connection.lost.body": "Your internet connection is offline, some features may not work properly",
-
   "popup.outdatedmicrobit.header": "Your micro:bit firmware is outdated.",
   "popup.outdatedmicrobit.text": "We strongly recommend that you update it now, as some features may not work as expected.",
   "popup.outdatedmicrobit.text.mkcd": "Open the newest MakeCode template to use the updated extension.",

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -105,7 +105,10 @@
             <div class="w-full pt-5 text-white pb-5">
               <TrainModelButton
                 selectedOption={selectedModelOption}
-                onClick={() => {resetLoss(); trackModelEvent();}}
+                onClick={() => {
+                  resetLoss();
+                  trackModelEvent();
+                }}
                 onTrainingIteration={trainingIterationHandler} />
             </div>
           {/if}

--- a/src/script/microbit-interfacing/MicrobitBluetooth.ts
+++ b/src/script/microbit-interfacing/MicrobitBluetooth.ts
@@ -340,14 +340,17 @@ export class MicrobitBluetooth {
    *      Fired if the request failed.
    */
   public static async requestDevice(
-    name: string,
     onRequestFailed: (e: Error) => void,
+    name?: string,
   ): Promise<BluetoothDevice> {
     return new Promise<BluetoothDevice>((resolve, reject) => {
+      const filters = name
+        ? [{ namePrefix: `BBC micro:bit [${name}]` }]
+        : [{ namePrefix: `BBC micro:bit` }];
       try {
         navigator.bluetooth
           .requestDevice({
-            filters: [{ namePrefix: `BBC micro:bit [${name}]` }],
+            filters: filters,
             optionalServices: [
               MBSpecs.Services.UART_SERVICE,
               MBSpecs.Services.ACCEL_SERVICE,

--- a/src/script/microbit-interfacing/connection-behaviours/ConnectionBehaviour.ts
+++ b/src/script/microbit-interfacing/connection-behaviours/ConnectionBehaviour.ts
@@ -35,13 +35,13 @@ interface ConnectionBehaviour {
    * @param {string} name
    *      The name of the micro:bit.
    */
-  onAssigned(microbit: MicrobitBluetooth, name: string): void;
+  onAssigned(microbit: MicrobitBluetooth, name?: string): void;
 
   /**
    * What should happen when the micro:bit gets connected via Bluetooth
    * @param name Name of the micro:bit
    */
-  onConnected(name: string): void;
+  onConnected(name?: string): void;
 
   /**
    * What should happen when the microbit is ready?

--- a/src/script/microbit-interfacing/connection-behaviours/InputBehaviour.ts
+++ b/src/script/microbit-interfacing/connection-behaviours/InputBehaviour.ts
@@ -79,7 +79,7 @@ class InputBehaviour extends LoggingDecorator {
     });
   }
 
-  onAssigned(microbitBluetooth: MicrobitBluetooth, name: string) {
+  onAssigned(microbitBluetooth: MicrobitBluetooth, name?: string) {
     super.onAssigned(microbitBluetooth, name);
     state.update(s => {
       s.isInputAssigned = true;
@@ -121,7 +121,7 @@ class InputBehaviour extends LoggingDecorator {
     });
   }
 
-  onConnected(name: string): void {
+  onConnected(name?: string): void {
     super.onConnected(name);
 
     state.update(s => {
@@ -134,7 +134,7 @@ class InputBehaviour extends LoggingDecorator {
     // Works like this: If the MB manages to connect, wait `reconnectTimeoutDuration` milliseconds
     // if MB does not call onReady before that expires, refresh the page
     clearTimeout(this.reconnectTimeout);
-    const onTimeout = () => onCatastrophicError();
+    const onTimeout = () => onCatastrophicError(!!name);
     this.reconnectTimeout = setTimeout(function () {
       onTimeout();
     }, StaticConfiguration.reconnectTimeoutDuration);

--- a/src/script/microbit-interfacing/connection-behaviours/LoggingDecorator.ts
+++ b/src/script/microbit-interfacing/connection-behaviours/LoggingDecorator.ts
@@ -61,7 +61,7 @@ abstract class LoggingDecorator implements ConnectionBehaviour {
     this.enableLogging && console.log('Button change', buttonState, button);
   }
 
-  onAssigned(microbit: MicrobitBluetooth, name: string): void {
+  onAssigned(microbit: MicrobitBluetooth, name?: string): void {
     this.enableLogging && console.log(name, ' was assigned ');
     this.enableLogging && console.log(microbit);
   }
@@ -70,7 +70,7 @@ abstract class LoggingDecorator implements ConnectionBehaviour {
     this.enableLogging && console.log('Device request was cancelled');
   }
 
-  onConnected(name: string): void {
+  onConnected(name?: string): void {
     this.enableLogging && console.log(name, ' got connected via bluetooth');
   }
 

--- a/src/script/microbit-interfacing/connection-behaviours/OutputBehaviour.ts
+++ b/src/script/microbit-interfacing/connection-behaviours/OutputBehaviour.ts
@@ -92,7 +92,7 @@ class OutputBehaviour extends LoggingDecorator {
     clearTimeout(this.reconnectTimeout);
   }
 
-  onAssigned(microbitBluetooth: MicrobitBluetooth, name: string) {
+  onAssigned(microbitBluetooth: MicrobitBluetooth, name?: string) {
     super.onAssigned(microbitBluetooth, name);
     state.update(s => {
       s.isOutputAssigned = true;
@@ -132,7 +132,7 @@ class OutputBehaviour extends LoggingDecorator {
     return;
   }
 
-  onConnected(name: string): void {
+  onConnected(name?: string): void {
     super.onConnected(name);
 
     state.update(s => {
@@ -144,7 +144,7 @@ class OutputBehaviour extends LoggingDecorator {
 
     // Reset connection reconnectTimeoutTime
     clearTimeout(this.reconnectTimeout);
-    const onTimeout = () => onCatastrophicError();
+    const onTimeout = () => onCatastrophicError(!!name);
     this.reconnectTimeout = setTimeout(function () {
       onTimeout();
     }, StaticConfiguration.reconnectTimeoutDuration);

--- a/src/script/stores/uiStore.ts
+++ b/src/script/stores/uiStore.ts
@@ -173,12 +173,13 @@ export const microbitInteraction = writable<MicrobitInteractions>(
 );
 
 /**
- * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium
+ * Workaround for an unrecoverable reconnect failure due to a bug in chrome/chromium.
+ * This error occurs, when a connection is established, but lost again before listening to the characteristics
  * Refresh the page is the only known solution
  */
-export const onCatastrophicError = () => {
+export const onCatastrophicError = (reconnect?: boolean) => {
   // Set flag to offer reconnect when page reloads
-  if (isInputPatternValid()) {
+  if (isInputPatternValid() && reconnect) {
     CookieManager.setReconnectFlag();
   }
   location.reload();


### PR DESCRIPTION
Fixes #480 

If the device request is cancelled, a link will appear, that allows for connecting micro:bits without specifying the name

![image](https://github.com/microbit-foundation/cctd-ml-machine/assets/6570193/48dbef63-dbca-4d2a-a74b-952fffcdd42d)

Do note that microbits connected without name does not support reconnect-prompt if the connection couldn't be recovered